### PR TITLE
Remove dependency on Guava

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,6 @@ release {
 }
 
 dependencies {
-    compile 'com.google.guava:guava:17.0'
     compile 'com.netflix.nebula:nebula-core:1.12.+'
     // TBD Make these optionals
     compile 'com.netflix.nebula:gradle-info-plugin:1.12.+'

--- a/src/main/groovy/nebula/plugin/publishing/component/CustomComponentPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/publishing/component/CustomComponentPlugin.groovy
@@ -1,6 +1,5 @@
 package nebula.plugin.publishing.component
 
-import com.google.common.base.Preconditions
 import nebula.core.AlternativeArchiveTask
 import nebula.plugin.publishing.ConfsVisiblePlugin
 import org.gradle.api.DomainObjectSet
@@ -8,7 +7,6 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.PublishArtifact
 import org.gradle.api.internal.DefaultDomainObjectSet
 import org.gradle.api.internal.artifacts.publish.ArchivePublishArtifact
@@ -76,7 +74,7 @@ class CustomComponentPlugin implements Plugin<Project> {
     }
 
     CustomUsage addUsage(String confName, PublishArtifact artifact = null, Configuration configuration = null, Set<String> confsToSkip = null) {
-        Preconditions.checkArgument(confName as Boolean)
+        assert confName as Boolean
 
         CustomUsage.DeferredDependencies deferredDependencies = configuration?new CustomUsage.DeferredDependencies(confName, configuration, confsToSkip):null
 

--- a/src/main/groovy/nebula/plugin/publishing/component/CustomUsage.groovy
+++ b/src/main/groovy/nebula/plugin/publishing/component/CustomUsage.groovy
@@ -1,7 +1,5 @@
 package nebula.plugin.publishing.component
 
-import com.google.common.collect.Lists
-import com.google.common.collect.Sets
 import groovy.transform.Canonical
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.Dependency
@@ -48,9 +46,9 @@ class CustomUsage implements Usage {
             CompositeDomainObjectSet<Dependency> inheritedDependencies;
             inheritedDependencies = new CompositeDomainObjectSet<Dependency>(Dependency.class, configuration.dependencies);
 
-            Queue<Configuration> confQueue = Lists.newLinkedList()
+            Queue<Configuration> confQueue = new LinkedList<>()
             confQueue.add(configuration)
-            Set<String> visited = confsToSkip?Sets.newHashSet(confsToSkip):Sets.newHashSet()
+            Set<String> visited = confsToSkip?new HashSet(confsToSkip):new HashSet()
             while (!confQueue.isEmpty()) {
                 Configuration extendsConf = confQueue.remove()
                 if (!visited.contains(extendsConf.name)) {

--- a/src/main/groovy/nebula/plugin/publishing/ivy/NebulaIvyPublishingPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/publishing/ivy/NebulaIvyPublishingPlugin.groovy
@@ -1,16 +1,12 @@
 package nebula.plugin.publishing.ivy
 
-import com.google.common.collect.HashMultimap
-import com.google.common.collect.Multimap
 import nebula.plugin.publishing.component.CustomComponentPlugin
 import nebula.plugin.publishing.component.CustomSoftwareComponent
 import nebula.plugin.publishing.component.CustomUsage
 import nebula.plugin.publishing.maven.MavenDistributePlugin
 import org.gradle.api.Action
-import org.gradle.api.DefaultTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.Task
 import org.gradle.api.artifacts.*
 import org.gradle.api.artifacts.repositories.ArtifactRepository
 import org.gradle.api.artifacts.repositories.IvyArtifactRepository
@@ -24,8 +20,6 @@ import org.gradle.api.publish.ivy.IvyPublication
 import org.gradle.api.publish.ivy.internal.dependency.DefaultIvyDependency
 import org.gradle.api.publish.ivy.internal.publication.DefaultIvyPublication
 import org.gradle.api.publish.ivy.tasks.PublishToIvyRepository
-import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
-import org.gradle.api.publish.plugins.PublishingPlugin
 
 /**
  * Analogous to NebulaMavenPublishingPlugin, but for Ivy. Netflix has some very specific requirements for the resulting
@@ -109,10 +103,10 @@ class NebulaIvyPublishingPlugin implements Plugin<Project> {
     }
 
     def ensureConfigurations(DefaultIvyPublication pub, String archiveConf, String dependencyConf) {
-        Multimap<String, String> confExtends = HashMultimap.create()
+        def confExtends = [:].withDefault {[]}
         if (archiveConf != dependencyConf) {
             // TODO This might be optional
-            confExtends.put(archiveConf, dependencyConf)
+            confExtends.archiveConf.add(dependencyConf)
         }
 
         def confsProcessed = [] as Set

--- a/src/main/groovy/nebula/plugin/publishing/xml/WithXmlAction.groovy
+++ b/src/main/groovy/nebula/plugin/publishing/xml/WithXmlAction.groovy
@@ -1,21 +1,19 @@
 package nebula.plugin.publishing.xml
 
-import com.google.common.base.Preconditions
-
 import java.util.logging.Logger
 
 class WithXmlAction {
     private static final Logger LOGGER = Logger.getLogger(WithXmlAction.getName())
 
-    private Node root
     private Closure closure
 
     WithXmlAction(Closure closure) {
-        this.closure = Preconditions.checkNotNull(closure, "Closure has to be set during constructor")
+        assert closure : "Closure has to be set during constructor"
+        this.closure = closure
     }
 
     def execute(Node root) {
-        Preconditions.checkNotNull(root)
+        assert root
 
         closure.delegate = new MissingPropertyToStringDelegate(root)
 

--- a/src/test/groovy/nebula/plugin/publishing/xml/WithXmlActionSpec.groovy
+++ b/src/test/groovy/nebula/plugin/publishing/xml/WithXmlActionSpec.groovy
@@ -1,6 +1,5 @@
 package nebula.plugin.publishing.xml
 
-import com.google.common.base.Preconditions
 import spock.lang.Specification
 
 import java.util.logging.Handler
@@ -59,8 +58,8 @@ class WithXmlActionSpec extends Specification {
         when:
         def builders = "build"
         execute { project ->
-            Preconditions.checkNotNull(project)
-            Preconditions.checkArgument(project instanceof Node)
+            assert project
+            assert project instanceof Node
             println "About to reference! ${owner} ${delegate}"
 
             def matrix = project / builders / builder


### PR DESCRIPTION
Prevent buildscript classpath from being polluted with a version later than gradleApi() provides.