### PR TITLE
Add nebula.maven-resolved-dependencies-jar to skip the after evaluate…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ script: "./buildViaTravis.sh"
 cache:
   directories:
   - "$HOME/.gradle/caches/"
-  - "$HOME/.gradle/dists/gradle-2.4-bin/"
+  - "$HOME/.gradle/dists/gradle-2.7-bin/"
 before_install:
 - test $TRAVIS_PULL_REQUEST = false && openssl aes-256-cbc -K $encrypted_4b7767003602_key -iv $encrypted_4b7767003602_iv
   -in gradle.properties.enc -out gradle.properties -d || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+4.2.0 / 2015-09-15
+==================
+
+* Add nebula.maven-resolved-dependencies-jar for projects that cannot use nebula.maven-resolved-dependencies due to other plugins resolving publications early
+
 4.1.0 / 2015-09-14
 ==================
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 To apply this plugin if using Gradle 2.1 or newer
 
     plugins {
-      id 'nebula.<publishing plugin of your choice>' version '4.1.0'
+      id 'nebula.<publishing plugin of your choice>' version '4.2.0'
     }
 
 If using an older version of Gradle
@@ -18,7 +18,7 @@ If using an older version of Gradle
     buildscript {
       repositories { jcenter() }
       dependencies {
-        classpath 'com.netflix.nebula:nebula-publishing-plugin:4.1.0'
+        classpath 'com.netflix.nebula:nebula-publishing-plugin:4.2.0'
       }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -147,6 +147,13 @@ pluginBundle {
             tags = ['nebula', 'publish', 'maven']
         }
 
+        mavenResolvedDependenciesJar {
+            id = 'nebula.maven-resolved-dependencies-jar'
+            displayName = 'Nebula Maven Resolved Dependencies Jar Plugin'
+            description = 'Built on top of nebula.maven-dependencies-jar, replacing dynamic versions with the actual resolved versions'
+            tags = ['nebula', 'publish', 'maven']
+        }
+
         mavenScm {
             id = 'nebula.maven-scm'
             displayName = 'Nebula Maven SCM Plugin'

--- a/src/main/groovy/nebula/plugin/publishing/maven/MavenResolvedDependenciesBase.groovy
+++ b/src/main/groovy/nebula/plugin/publishing/maven/MavenResolvedDependenciesBase.groovy
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nebula.plugin.publishing.maven
+
+import org.gradle.api.Project
+import org.gradle.api.XmlProvider
+import org.gradle.api.artifacts.component.ModuleComponentSelector
+import org.gradle.api.artifacts.result.ResolvedDependencyResult
+import org.gradle.api.publish.maven.MavenPublication
+
+class MavenResolvedDependenciesBase {
+    void addResolveRules(Project project) {
+        project.publishing {
+            publications {
+                nebula(MavenPublication) {
+                    pom.withXml { XmlProvider xml->
+                        def dependencies = xml.asNode()?.dependencies?.dependency
+                        def dependencyMap = [:]
+
+                        dependencyMap['runtime'] = project.configurations.runtime.incoming.resolutionResult.allDependencies
+                        dependencyMap['test'] = project.configurations.testRuntime.incoming.resolutionResult.allDependencies - dependencyMap['runtime']
+                        dependencies?.each { Node dep ->
+                            def group = dep.groupId.text()
+                            def name = dep.artifactId.text()
+                            def scope = dep.scope.text()
+
+                            if (scope == 'provided') {
+                                scope = 'runtime'
+                            }
+
+                            ResolvedDependencyResult resolved = dependencyMap[scope].find { r ->
+                                (r.requested instanceof ModuleComponentSelector) &&
+                                        (r.requested.group == group) &&
+                                        (r.requested.module == name)
+                            }
+
+                            if (!resolved) {
+                                return  // continue loop if a dependency is not found in dependencyMap
+                            }
+
+                            def versionNode = dep.version
+                            if (!versionNode) {
+                                versionNode = dep.appendNode('version')
+                            }
+                            dep.version[0].value = resolved?.selected?.moduleVersion?.version
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/groovy/nebula/plugin/publishing/maven/MavenResolvedDependenciesJarPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/publishing/maven/MavenResolvedDependenciesJarPlugin.groovy
@@ -18,13 +18,10 @@ package nebula.plugin.publishing.maven
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
-/**
- * Replaces dynamic constraints with fixed constraints
- */
-class MavenResolvedDependenciesPlugin implements Plugin<Project> {
+class MavenResolvedDependenciesJarPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
-        project.plugins.apply(MavenDependenciesPlugin)
+        project.plugins.apply(MavenDependenciesJarPlugin)
 
         new MavenResolvedDependenciesBase().addResolveRules(project)
     }

--- a/src/main/resources/META-INF/gradle-plugins/nebula.maven-resolved-dependencies-jar.properties
+++ b/src/main/resources/META-INF/gradle-plugins/nebula.maven-resolved-dependencies-jar.properties
@@ -1,0 +1,1 @@
+implementation-class=nebula.plugin.publishing.maven.MavenResolvedDependenciesJarPlugin

--- a/src/test/groovy/nebula/plugin/publishing/maven/MavenResolvedDependenciesJarPluginIntegrationSpec.groovy
+++ b/src/test/groovy/nebula/plugin/publishing/maven/MavenResolvedDependenciesJarPluginIntegrationSpec.groovy
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nebula.plugin.publishing.maven
+
+import nebula.test.IntegrationSpec
+import nebula.test.dependencies.DependencyGraphBuilder
+import nebula.test.dependencies.GradleDependencyGenerator
+
+class MavenResolvedDependenciesJarPluginIntegrationSpec extends IntegrationSpec {
+    File publishDir
+
+    def setup() {
+        buildFile << """\
+            ${applyPlugin(MavenResolvedDependenciesPlugin)}
+
+            version = '0.1.0'
+            group = 'test.nebula'
+
+            publishing {
+                repositories {
+                    maven {
+                        name = 'testLocal'
+                        url = 'testrepo'
+                    }
+                }
+            }
+        """.stripIndent()
+
+        settingsFile << '''\
+            rootProject.name = 'resolvedmaventest'
+        '''.stripIndent()
+
+        publishDir = new File(projectDir, 'testrepo/test/nebula/resolvedmaventest/0.1.0')
+    }
+
+    def 'dynamic versions are replaced by the resolved version'() {
+        def graph = new DependencyGraphBuilder().addModule('test.resolved:a:1.0.0')
+                .addModule('test.resolved:a:1.1.0').build()
+        File mavenrepo = new GradleDependencyGenerator(graph, "${projectDir}/testrepogen").generateTestMavenRepo()
+
+        buildFile << """\
+            apply plugin: 'java'
+
+            repositories { maven { url '${mavenrepo.absolutePath}' } }
+
+            dependencies {
+                compile 'test.resolved:a:1.+'
+            }
+        """.stripIndent()
+
+        when:
+        runTasksSuccessfully('publishNebulaPublicationToTestLocalRepository')
+
+        then:
+        def root = new XmlSlurper().parseText(new File(publishDir, 'resolvedmaventest-0.1.0.pom').text)
+        def dependency = root.dependencies.dependency[0]
+        dependency.version.text() == '1.1.0'
+    }
+}


### PR DESCRIPTION
… if a project knows it will produce a jar