### PR TITLE
Ensure published metadata includes selected name and group

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ plugins {
     id 'nebula.nebula-release' version '3.0.5'
     id 'nebula.nebula-bintray' version '3.1.0'
     id 'nebula.optional-base' version '3.0.3'
+    id 'nebula.dependency-lock' version '4.3.0'
     id 'com.gradle.plugin-publish' version '0.9.4'
     id 'com.github.kt3k.coveralls' version '2.4.0'
     id 'org.ysb33r.gradletest' version '0.5.4'
@@ -53,15 +54,15 @@ task createClasspathManifest {
 }
 
 dependencies {
-    compile localGroovy()
     compile gradleApi()
-    compile 'com.netflix.nebula:nebula-core:3.0.0'
-    compile 'com.netflix.nebula:gradle-info-plugin:3.0.3', optional
-    compile 'com.netflix.nebula:gradle-contacts-plugin:3.0.1', optional
-    testCompile('com.netflix.nebula:nebula-test:4.0.0') {
+    compile 'com.netflix.nebula:nebula-core:latest.release'
+    compile 'com.netflix.nebula:gradle-info-plugin:latest.release', optional
+    compile 'com.netflix.nebula:gradle-contacts-plugin:latest.release', optional
+
+    testCompile gradleTestKit()
+    testCompile('com.netflix.nebula:nebula-test:latest.release') {
         exclude group: 'org.codehaus.groovy'
     }
-    testCompile gradleTestKit()
     testCompile('org.spockframework:spock-core:1.0-groovy-2.4') {
         exclude group: 'org.codehaus.groovy'
     }

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -1,0 +1,170 @@
+{
+    "compile": {
+        "com.netflix.nebula:gradle-contacts-plugin": {
+            "locked": "3.0.1",
+            "requested": "latest.release"
+        },
+        "com.netflix.nebula:gradle-info-plugin": {
+            "locked": "3.1.0",
+            "requested": "latest.release"
+        },
+        "com.netflix.nebula:nebula-core": {
+            "locked": "3.1.0",
+            "requested": "latest.release"
+        }
+    },
+    "compileClasspath": {
+        "com.netflix.nebula:gradle-contacts-plugin": {
+            "locked": "3.0.1",
+            "requested": "latest.release"
+        },
+        "com.netflix.nebula:gradle-info-plugin": {
+            "locked": "3.1.0",
+            "requested": "latest.release"
+        },
+        "com.netflix.nebula:nebula-core": {
+            "locked": "3.1.0",
+            "requested": "latest.release"
+        }
+    },
+    "compileOnly": {
+        "com.netflix.nebula:gradle-contacts-plugin": {
+            "locked": "3.0.1",
+            "requested": "latest.release"
+        },
+        "com.netflix.nebula:gradle-info-plugin": {
+            "locked": "3.1.0",
+            "requested": "latest.release"
+        },
+        "com.netflix.nebula:nebula-core": {
+            "locked": "3.1.0",
+            "requested": "latest.release"
+        }
+    },
+    "default": {
+        "com.netflix.nebula:gradle-contacts-plugin": {
+            "locked": "3.0.1",
+            "requested": "latest.release"
+        },
+        "com.netflix.nebula:gradle-info-plugin": {
+            "locked": "3.1.0",
+            "requested": "latest.release"
+        },
+        "com.netflix.nebula:nebula-core": {
+            "locked": "3.1.0",
+            "requested": "latest.release"
+        }
+    },
+    "jacocoAgent": {
+        "org.jacoco:org.jacoco.agent": {
+            "locked": "0.7.6.201602180812"
+        }
+    },
+    "jacocoAnt": {
+        "org.jacoco:org.jacoco.ant": {
+            "locked": "0.7.6.201602180812"
+        }
+    },
+    "runtime": {
+        "com.netflix.nebula:gradle-contacts-plugin": {
+            "locked": "3.0.1",
+            "requested": "latest.release"
+        },
+        "com.netflix.nebula:gradle-info-plugin": {
+            "locked": "3.1.0",
+            "requested": "latest.release"
+        },
+        "com.netflix.nebula:nebula-core": {
+            "locked": "3.1.0",
+            "requested": "latest.release"
+        }
+    },
+    "testCompile": {
+        "com.netflix.nebula:gradle-contacts-plugin": {
+            "locked": "3.0.1",
+            "requested": "latest.release"
+        },
+        "com.netflix.nebula:gradle-info-plugin": {
+            "locked": "3.1.0",
+            "requested": "latest.release"
+        },
+        "com.netflix.nebula:nebula-core": {
+            "locked": "3.1.0",
+            "requested": "latest.release"
+        },
+        "com.netflix.nebula:nebula-test": {
+            "locked": "4.0.0",
+            "requested": "latest.release"
+        },
+        "org.spockframework:spock-core": {
+            "locked": "1.0-groovy-2.4",
+            "requested": "1.0-groovy-2.4"
+        }
+    },
+    "testCompileClasspath": {
+        "com.netflix.nebula:gradle-contacts-plugin": {
+            "locked": "3.0.1",
+            "requested": "latest.release"
+        },
+        "com.netflix.nebula:gradle-info-plugin": {
+            "locked": "3.1.0",
+            "requested": "latest.release"
+        },
+        "com.netflix.nebula:nebula-core": {
+            "locked": "3.1.0",
+            "requested": "latest.release"
+        },
+        "com.netflix.nebula:nebula-test": {
+            "locked": "4.0.0",
+            "requested": "latest.release"
+        },
+        "org.spockframework:spock-core": {
+            "locked": "1.0-groovy-2.4",
+            "requested": "1.0-groovy-2.4"
+        }
+    },
+    "testCompileOnly": {
+        "com.netflix.nebula:gradle-contacts-plugin": {
+            "locked": "3.0.1",
+            "requested": "latest.release"
+        },
+        "com.netflix.nebula:gradle-info-plugin": {
+            "locked": "3.1.0",
+            "requested": "latest.release"
+        },
+        "com.netflix.nebula:nebula-core": {
+            "locked": "3.1.0",
+            "requested": "latest.release"
+        },
+        "com.netflix.nebula:nebula-test": {
+            "locked": "4.0.0",
+            "requested": "latest.release"
+        },
+        "org.spockframework:spock-core": {
+            "locked": "1.0-groovy-2.4",
+            "requested": "1.0-groovy-2.4"
+        }
+    },
+    "testRuntime": {
+        "com.netflix.nebula:gradle-contacts-plugin": {
+            "locked": "3.0.1",
+            "requested": "latest.release"
+        },
+        "com.netflix.nebula:gradle-info-plugin": {
+            "locked": "3.1.0",
+            "requested": "latest.release"
+        },
+        "com.netflix.nebula:nebula-core": {
+            "locked": "3.1.0",
+            "requested": "latest.release"
+        },
+        "com.netflix.nebula:nebula-test": {
+            "locked": "4.0.0",
+            "requested": "latest.release"
+        },
+        "org.spockframework:spock-core": {
+            "locked": "1.0-groovy-2.4",
+            "requested": "1.0-groovy-2.4"
+        }
+    }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,4 +1,4 @@
-#Mon Apr 25 15:07:04 PDT 2016
+#Tue May 10 16:21:56 PDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/groovy/nebula/plugin/publishing/ivy/IvyResolvedDependenciesPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/publishing/ivy/IvyResolvedDependenciesPlugin.groovy
@@ -59,7 +59,11 @@ class IvyResolvedDependenciesPlugin implements Plugin<Project> {
                                 if (!resolved) {
                                     return  // continue loop if a dependency is not found in dependencyMap
                                 }
-                                dep.@rev = resolved?.selected?.moduleVersion?.version
+
+                                def moduleVersion = resolved.selected.moduleVersion
+                                dep.@org = moduleVersion.group
+                                dep.@name = moduleVersion.name
+                                dep.@rev = moduleVersion.version
                             }
                         }
                     }

--- a/src/main/groovy/nebula/plugin/publishing/maven/MavenResolvedDependenciesPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/publishing/maven/MavenResolvedDependenciesPlugin.groovy
@@ -62,9 +62,12 @@ class MavenResolvedDependenciesPlugin implements Plugin<Project> {
 
                                 def versionNode = dep.version
                                 if (!versionNode) {
-                                    versionNode = dep.appendNode('version')
+                                    dep.appendNode('version')
                                 }
-                                dep.version[0].value = resolved?.selected?.moduleVersion?.version
+                                def moduleVersion = resolved.selected.moduleVersion
+                                dep.groupId[0].value = moduleVersion.group
+                                dep.artifactId[0].value = moduleVersion.name
+                                dep.version[0].value = moduleVersion.version
                             }
                         }
                     }

--- a/src/test/groovy/nebula/plugin/publishing/ivy/IvyBasePublishPluginIntegrationSpec.groovy
+++ b/src/test/groovy/nebula/plugin/publishing/ivy/IvyBasePublishPluginIntegrationSpec.groovy
@@ -223,6 +223,7 @@ class IvyBasePublishPluginIntegrationSpec extends IntegrationHelperSpec {
     boolean assertDependency(String org, String name, String rev, String conf = null) {
         def dependencies = new XmlSlurper().parse(new File(publishDir, 'ivy-0.1.0.xml')).dependencies.dependency
         def found = dependencies.find { it.@name == name && it.@org == org }
+        assert found
         assert found.@rev == rev
         assert !conf || found.@conf == conf
         found


### PR DESCRIPTION
By default module replacements, resolution strategies etc. aren't considered when publishing. This ensures that they are.