### PR TITLE
Add provided scope check to Maven fallback

### DIFF
--- a/src/main/groovy/nebula/plugin/publishing/ivy/AbstractResolvedDependenciesPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/publishing/ivy/AbstractResolvedDependenciesPlugin.groovy
@@ -23,16 +23,16 @@ abstract class AbstractResolvedDependenciesPlugin implements Plugin<Project> {
         if (exclude) {
             throw new GradleException("Direct dependency \"${group}:${name}\" is excluded, delete direct dependency or stop excluding it")
         }
+
         ResolvedDependencyResult result = lookupDependency(project, scope, group, name)
-        if (!result) {
-            if (scope == 'compile') {
-                result = lookupDependency(project, 'runtime', group, name)
-            }
-            if (!result) {
-                return null
-            }
+
+        Map<String, String> scoping = [compile: 'runtime', provided: 'compileOnly']
+
+        if (!result && scoping[scope]) {
+            result = lookupDependency(project, scoping[scope], group, name)
         }
-        result.selected.moduleVersion
+
+        result?.selected?.moduleVersion
     }
 
     private ResolvedDependencyResult lookupDependency(Project project, String scope, String group, String name) {

--- a/src/test/groovy/nebula/plugin/publishing/ivy/interaction/IvyPublishRecommenderInteractionSpec.groovy
+++ b/src/test/groovy/nebula/plugin/publishing/ivy/interaction/IvyPublishRecommenderInteractionSpec.groovy
@@ -3,10 +3,11 @@ package nebula.plugin.publishing.ivy.interaction
 import nebula.test.IntegrationTestKitSpec
 import nebula.test.dependencies.DependencyGraphBuilder
 import nebula.test.dependencies.GradleDependencyGenerator
+import spock.lang.Unroll
 
 class IvyPublishRecommenderInteractionSpec extends IntegrationTestKitSpec {
-    def 'dependencies in runtime provided by recommender are not put in ivy file'() {
-        keepFiles = true
+    @Unroll
+    def 'dependencies from recommendation plugin in #scope scope should be in ivy file'() {
         def graph = new DependencyGraphBuilder().addModule('test:foo:1.0.0').build()
         def generator = new GradleDependencyGenerator(graph, "$projectDir/repo")
         generator.generateTestMavenRepo()
@@ -32,7 +33,7 @@ class IvyPublishRecommenderInteractionSpec extends IntegrationTestKitSpec {
             }
 
             dependencies {
-                runtime 'test:foo'
+                $scope 'test:foo'
             }
 
             publishing {
@@ -50,6 +51,10 @@ class IvyPublishRecommenderInteractionSpec extends IntegrationTestKitSpec {
 
         then:
         def ivy = new XmlSlurper().parse(new File(projectDir, 'build/testlocal/test.nebula/mytest/0.1.0/ivy-0.1.0.xml'))
-        ivy.dependencies.dependency[0].@rev == '1.0.0'
+        ivy.dependencies.dependency.first().@rev == '1.0.0'
+
+        where:
+        scope << ['runtime', 'compile', 'compileOnly', 'runtimeOnly']
+
     }
 }


### PR DESCRIPTION
Add more test cases to specification to ensure that multiple scopes are discoverable in the output ivy manifest.