### PR TITLE
Add Apache License to all MavenPublications

### DIFF
--- a/src/main/groovy/nebula/plugin/publishing/maven/license/MavenApacheLicensePlugin.groovy
+++ b/src/main/groovy/nebula/plugin/publishing/maven/license/MavenApacheLicensePlugin.groovy
@@ -28,15 +28,20 @@ class MavenApacheLicensePlugin implements Plugin<Project> {
 
         project.publishing {
             publications {
-                nebula(MavenPublication) {
-                    pom.licenses {
-                        license {
-                            name = 'The Apache Software License, Version 2.0'
-                            url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                            distribution = 'repo'
-                        }
-                    }
+                nebula(MavenPublication)
+                withType(MavenPublication) { publication ->
+                    configureLicense(publication)
                 }
+            }
+        }
+    }
+
+    def configureLicense(MavenPublication publication) {
+        publication.pom.licenses {
+            license {
+                name = 'The Apache Software License, Version 2.0'
+                url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                distribution = 'repo'
             }
         }
     }

--- a/src/test/groovy/nebula/plugin/publishing/maven/license/MavenApacheLicensePluginIntegrationSpec.groovy
+++ b/src/test/groovy/nebula/plugin/publishing/maven/license/MavenApacheLicensePluginIntegrationSpec.groovy
@@ -19,6 +19,8 @@ import nebula.test.IntegrationTestKitSpec
 
 class MavenApacheLicensePluginIntegrationSpec extends IntegrationTestKitSpec {
     def 'add license works'() {
+        given:
+        keepFiles = true
         buildFile << """\
             plugins {
                 id 'nebula.maven-apache-license'
@@ -30,6 +32,7 @@ class MavenApacheLicensePluginIntegrationSpec extends IntegrationTestKitSpec {
 
         settingsFile << '''\
             rootProject.name = 'apachelicensepomtest'
+            enableFeaturePreview('STABLE_PUBLISHING')
         '''.stripIndent()
 
         when:
@@ -37,6 +40,83 @@ class MavenApacheLicensePluginIntegrationSpec extends IntegrationTestKitSpec {
 
         then:
         def pom = new XmlSlurper().parse(new File(projectDir, 'build/publications/nebula/pom-default.xml'))
+        pom.licenses.license.name.text() == 'The Apache Software License, Version 2.0'
+        pom.licenses.license.url.text() == 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+        pom.licenses.license.distribution.text() == 'repo'
+    }
+
+    def 'add license works for maven plugin publication'() {
+        given:
+        keepFiles = true
+        buildFile << """
+plugins {
+    id 'nebula.maven-apache-license'
+    id 'java-gradle-plugin'
+    id 'com.gradle.plugin-publish' version "0.10.0"
+    id 'maven-publish'
+}
+
+version = '0.1.0'
+group = 'test.nebula'
+
+gradlePlugin {
+    plugins {
+        samplePlugin {
+            id = 'example.sample-plugin'
+            displayName = 'Sample plugin'
+            description = "Plugin that is a sample"
+            implementationClass = 'SamplePlugin'
+        }
+    }
+}
+
+pluginBundle {
+    tags = ['sample']
+}
+
+publishing {
+    publications {
+        // publish with a customized POM
+        pluginMaven(MavenPublication) {
+            pom {
+                name = 'apachelicensepomtest pom!'
+                inceptionYear = '2018'
+            }
+        }
+    }
+}
+""".stripIndent()
+
+        settingsFile << '''\
+            rootProject.name = 'apachelicensepomtest'
+            enableFeaturePreview('STABLE_PUBLISHING')
+        '''.stripIndent()
+
+
+        def classesDir = new File(projectDir.path, 'src/main/java')
+        classesDir.mkdirs()
+        def samplePluginFile = new File(classesDir, 'SamplePlugin.groovy')
+        samplePluginFile.createNewFile()
+        samplePluginFile << """
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.logging.Logger
+import org.gradle.api.logging.Logging
+
+class SamplePlugin implements Plugin<Project> {
+    Logger logger = Logging.getLogger(SamplePlugin);
+    Project project
+    void apply(Project project) {
+        this.project = project
+    }
+}
+"""
+
+        when:
+        runTasks('generatePomFileForPluginMavenPublication')
+
+        then:
+        def pom = new XmlSlurper().parse(new File(projectDir, "build/publications/pluginMaven/pom-default.xml"))
         pom.licenses.license.name.text() == 'The Apache Software License, Version 2.0'
         pom.licenses.license.url.text() == 'http://www.apache.org/licenses/LICENSE-2.0.txt'
         pom.licenses.license.distribution.text() == 'repo'


### PR DESCRIPTION
Keeps the 'nebula' type of maven publication, then adds to license to all publication types