### PR TITLE
enable strong typing for MavenDeveloperPlugin

### DIFF
--- a/src/main/groovy/nebula/plugin/publishing/contacts/BaseContactPluginConfigurator.groovy
+++ b/src/main/groovy/nebula/plugin/publishing/contacts/BaseContactPluginConfigurator.groovy
@@ -1,0 +1,31 @@
+package nebula.plugin.publishing.contacts
+
+import nebula.plugin.contacts.BaseContactsPlugin
+import nebula.plugin.contacts.Contact
+import org.gradle.api.publish.maven.MavenPublication
+
+class BaseContactPluginConfigurator {
+
+    static void configureContacts(BaseContactsPlugin contactsPlugin, MavenPublication publication) {
+        publication.pom.developers {
+            def myContacts = contactsPlugin.getAllContacts()
+            myContacts.each { Contact contact ->
+                developer {
+                    if (contact.github) {
+                        id = contact.github
+                    } else if (contact.twitter) {
+                        id = contact.twitter
+                    }
+                    if (contact.moniker) {
+                        name = contact.moniker
+                    }
+
+                    email = contact.email
+                    if (contact.roles) {
+                        roles = contact.roles
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/groovy/nebula/plugin/publishing/maven/MavenDeveloperPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/publishing/maven/MavenDeveloperPlugin.groovy
@@ -15,6 +15,7 @@
  */
 package nebula.plugin.publishing.maven
 
+import nebula.plugin.publishing.contacts.BaseContactPluginConfigurator
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.publish.maven.MavenPublication
@@ -30,34 +31,11 @@ class MavenDeveloperPlugin implements Plugin<Project> {
                     withType(MavenPublication) { publication ->
                         if (! project.state.executed) {
                             project.afterEvaluate {
-                                configureContacts(contactsPlugin, publication)
+                                BaseContactPluginConfigurator.configureContacts(contactsPlugin, publication)
                             }
                         } else {
-                            configureContacts(contactsPlugin, publication)
+                            BaseContactPluginConfigurator.configureContacts(contactsPlugin, publication)
                         }
-                    }
-                }
-            }
-        }
-    }
-
-    private void configureContacts(contactsPlugin, MavenPublication publication) {
-        publication.pom.developers {
-            def myContacts = contactsPlugin.getAllContacts()
-            myContacts.each { contact ->
-                developer {
-                    if (contact.github) {
-                        id = contact.github
-                    } else if (contact.twitter) {
-                        id = contact.twitter
-                    }
-                    if (contact.moniker) {
-                        name = contact.moniker
-                    }
-
-                    email = contact.email
-                    if (contact.roles) {
-                        roles = contact.roles
                     }
                 }
             }


### PR DESCRIPTION
With Gradle 5.1 or older, we are able to apply the plugin and hit the catch block when the optional dependency is not present (https://github.com/nebula-plugins/nebula-publishing-plugin/blob/master/src/main/groovy/nebula/plugin/publishing/maven/MavenDeveloperPlugin.groovy#L32).
However, if we try to apply the plugin in a project that doesn't have the `gradle-contacts-plugin` dependency as part of the classpath, we get the following error when applying the plugin:
```
Caused by: org.gradle.api.plugins.PluginInstantiationException: Could not create plugin of type 'MavenDeveloperPlugin'.
    at org.gradle.api.internal.plugins.DefaultPluginManager.instantiatePlugin(DefaultPluginManager.java:82)
    at org.gradle.api.internal.plugins.DefaultPluginManager.producePluginInstance(DefaultPluginManager.java:196)
    at org.gradle.api.internal.plugins.DefaultPluginManager.addPlugin(DefaultPluginManager.java:172)
    at org.gradle.api.internal.plugins.DefaultPluginManager.access$300(DefaultPluginManager.java:51)
    at org.gradle.api.internal.plugins.DefaultPluginManager$AddPluginBuildOperation.run(DefaultPluginManager.java:267)
    at org.gradle.internal.operations.DefaultBuildOperationExecutor$RunnableBuildOperationWorker.execute(DefaultBuildOperationExecutor.java:402)
    at org.gradle.internal.operations.DefaultBuildOperationExecutor$RunnableBuildOperationWorker.execute(DefaultBuildOperationExecutor.java:394)
    at org.gradle.internal.operations.DefaultBuildOperationExecutor$1.execute(DefaultBuildOperationExecutor.java:165)
    at org.gradle.internal.operations.DefaultBuildOperationExecutor.execute(DefaultBuildOperationExecutor.java:250)
    at org.gradle.internal.operations.DefaultBuildOperationExecutor.execute(DefaultBuildOperationExecutor.java:158)
    at org.gradle.internal.operations.DefaultBuildOperationExecutor.run(DefaultBuildOperationExecutor.java:92)
    at org.gradle.internal.operations.DelegatingBuildOperationExecutor.run(DelegatingBuildOperationExecutor.java:31)
    at org.gradle.api.internal.plugins.DefaultPluginManager$2.execute(DefaultPluginManager.java:155)
    at org.gradle.api.internal.plugins.DefaultPluginManager$2.execute(DefaultPluginManager.java:152)
    at org.gradle.configuration.internal.DefaultUserCodeApplicationContext.apply(DefaultUserCodeApplicationContext.java:48)
    at org.gradle.api.internal.plugins.DefaultPluginManager.doApply(DefaultPluginManager.java:152)
    ... 155 more
Caused by: org.gradle.api.internal.ClassGenerationException: Could not generate a decorated class for class nebula.plugin.publishing.maven.MavenDeveloperPlugin.
    at org.gradle.api.internal.AbstractClassGenerator.generateUnderLock(AbstractClassGenerator.java:127)
    at org.gradle.api.internal.AbstractClassGenerator.generate(AbstractClassGenerator.java:76)
    at org.gradle.api.internal.instantiation.Jsr330ConstructorSelector$1.transform(Jsr330ConstructorSelector.java:53)
    at org.gradle.api.internal.instantiation.Jsr330ConstructorSelector$1.transform(Jsr330ConstructorSelector.java:48)
    at org.gradle.cache.internal.DefaultCrossBuildInMemoryCacheFactory$DefaultCrossBuildInMemoryCache.get(DefaultCrossBuildInMemoryCacheFactory.java:121)
    at org.gradle.api.internal.instantiation.Jsr330ConstructorSelector.forParams(Jsr330ConstructorSelector.java:48)
    at org.gradle.api.internal.DependencyInjectingInstantiator.findConstructor(DependencyInjectingInstantiator.java:61)
    at org.gradle.api.internal.DependencyInjectingInstantiator.newInstance(DependencyInjectingInstantiator.java:46)
    at org.gradle.api.internal.plugins.DefaultPluginManager.instantiatePlugin(DefaultPluginManager.java:80)
    ... 170 more
Caused by: java.lang.NoClassDefFoundError: nebula/plugin/contacts/BaseContactsPlugin
    at org.gradle.internal.reflect.ClassInspector.inspectClass(ClassInspector.java:69)
    at org.gradle.internal.reflect.ClassInspector.visitGraph(ClassInspector.java:55)
    at org.gradle.internal.reflect.ClassInspector.inspect(ClassInspector.java:35)
    at org.gradle.api.internal.AbstractClassGenerator.inspectType(AbstractClassGenerator.java:138)
    at org.gradle.api.internal.AbstractClassGenerator.generateUnderLock(AbstractClassGenerator.java:106)
    ... 178 more
Caused by: java.lang.ClassNotFoundException: nebula.plugin.contacts.BaseContactsPlugin
    ... 183 more
```

From gradle folks:

> Just got confirmation that’s indeed a consequence of work to support `@Inject` in plugins.

This change is to keep us using strong typing for configuring contacts plugin