### PR TITLE
Remove MavenCompileOnlyPlugin config in build file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,11 +73,6 @@ gradlePlugin {
             implementationClass = 'nebula.plugin.publishing.maven.MavenBasePublishPlugin'
         }
 
-        mavenCompileOnly {
-            id = 'nebula.maven-compile-only'
-            implementationClass = 'nebula.plugin.publishing.maven.MavenCompileOnlyPlugin'
-        }
-
         mavenDeveloper {
             id = 'nebula.maven-developer'
             implementationClass = 'nebula.plugin.publishing.maven.MavenDeveloperPlugin'


### PR DESCRIPTION
Following on from PR #132. This was causing publication to fail: https://travis-ci.org/nebula-plugins/nebula-publishing-plugin/builds/532566068