### PR TITLE
Using proper repositories and fixing tests which were having incorrect assumption.

### DIFF
--- a/src/test/groovy/nebula/plugin/publishing/ivy/IvyRemovePlatformDependenciesPluginSpec.groovy
+++ b/src/test/groovy/nebula/plugin/publishing/ivy/IvyRemovePlatformDependenciesPluginSpec.groovy
@@ -47,7 +47,7 @@ class IvyRemovePlatformDependenciesPluginSpec extends IntegrationSpec {
 
             repositories {
                 ${generator.ivyRepositoryBlock}
-                mavenCentral()
+                jcenter()
             }
 
             dependencies {
@@ -99,7 +99,7 @@ class IvyRemovePlatformDependenciesPluginSpec extends IntegrationSpec {
 
             repositories {
                 ${generator.ivyRepositoryBlock}
-                mavenCentral()
+                jcenter()
             }
 
             dependencies {
@@ -150,7 +150,7 @@ class IvyRemovePlatformDependenciesPluginSpec extends IntegrationSpec {
 
             repositories {
                 ${generator.ivyRepositoryBlock}
-                mavenCentral()
+                jcenter()
             }
 
             dependencies {
@@ -167,7 +167,7 @@ class IvyRemovePlatformDependenciesPluginSpec extends IntegrationSpec {
         a.@rev == '1.1.0'
 
         def bom = findDependency('jenkins-bom')
-        bom.@rev == 'latest.release'
+        bom != null
     }
 
     def 'publishes ivy descriptor with enforced-platform dependency if plugin is not applied'() {
@@ -201,7 +201,7 @@ class IvyRemovePlatformDependenciesPluginSpec extends IntegrationSpec {
 
             repositories {
                 ${generator.ivyRepositoryBlock}
-                mavenCentral()
+                jcenter()
             }
 
             dependencies {
@@ -218,7 +218,7 @@ class IvyRemovePlatformDependenciesPluginSpec extends IntegrationSpec {
         a.@rev == '1.1.0'
 
         def bom = findDependency('jenkins-bom')
-        bom.@rev == 'latest.release'
+        bom != null
     }
 
 


### PR DESCRIPTION
`jenkins-bom` platforms were unresolvable because they are not in mavenCentral() but in jcenter(). Because of that we had incorrect assertion in the test to the version `latest.release`.
However it should be some exact version. We have resolved version publishing was enabled in the test. It showcased in our internal testing where we are injecting internal repositories.
Internal repositories give us access to jcenter and tests began to fail.