### PR TITLE
Introduce SpringBootJarPlugin and ShadowJar to make sure that we can publish Jar generated from bootJar/shadowJar tasks and nebula maven/ivy publish opinions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -162,6 +162,11 @@ gradlePlugin {
             implementationClass = 'nebula.plugin.publishing.publications.SourceJarPlugin'
         }
 
+        springBootJar {
+            id = 'nebula.spring-boot-jar'
+            implementationClass = 'nebula.plugin.publishing.publications.SpringBootJarPlugin'
+        }
+
         testJar {
             id = 'nebula.test-jar'
             implementationClass = 'nebula.plugin.publishing.publications.TestJarPlugin'
@@ -307,6 +312,13 @@ pluginBundle {
             displayName = 'Nebula Source Jar Publishing plugin'
             description = 'Create a sourceJar task to package up the project\'s source code and add it to the publications'
             tags = ['nebula', 'publish', 'source']
+        }
+
+        springBootJar {
+            id = 'nebula.spring-boot-jar'
+            displayName = 'Nebula Spring Boot Jar Publishing plugin'
+            description = 'Configures project to use bootJar artifact instead of jar artifact'
+            tags = ['nebula', 'publish', 'spring-boot']
         }
 
         testJar {

--- a/build.gradle
+++ b/build.gradle
@@ -162,6 +162,11 @@ gradlePlugin {
             implementationClass = 'nebula.plugin.publishing.publications.SourceJarPlugin'
         }
 
+        shadowJar {
+            id = 'nebula.shadow-jar'
+            implementationClass = 'nebula.plugin.publishing.publications.ShadowJarPlugin'
+        }
+
         springBootJar {
             id = 'nebula.spring-boot-jar'
             implementationClass = 'nebula.plugin.publishing.publications.SpringBootJarPlugin'
@@ -319,6 +324,13 @@ pluginBundle {
             displayName = 'Nebula Spring Boot Jar Publishing plugin'
             description = 'Configures project to use bootJar artifact instead of jar artifact'
             tags = ['nebula', 'publish', 'spring-boot']
+        }
+
+        shadowJar {
+            id = 'nebula.shadow-jar'
+            displayName = 'Nebula Shadow Jar Publishing plugin'
+            description = 'Configures project to use shadowJar artifact instead of jar artifact when users want to replace the jar task'
+            tags = ['nebula', 'publish', 'shadow']
         }
 
         testJar {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-bin.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-6.2-rc-1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/groovy/nebula/plugin/publishing/ivy/IvyPublishPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/publishing/ivy/IvyPublishPlugin.groovy
@@ -15,6 +15,7 @@
  */
 package nebula.plugin.publishing.ivy
 
+import nebula.plugin.publishing.publications.SpringBootJarPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
@@ -29,5 +30,7 @@ class IvyPublishPlugin implements Plugin<Project> {
         project.plugins.apply IvyManifestPlugin
         project.plugins.apply IvyRemovePlatformDependenciesPlugin
         project.plugins.apply IvyRemoveInvalidDependenciesPlugin
+        project.plugins.apply SpringBootJarPlugin
+
     }
 }

--- a/src/main/groovy/nebula/plugin/publishing/ivy/IvyPublishPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/publishing/ivy/IvyPublishPlugin.groovy
@@ -15,6 +15,7 @@
  */
 package nebula.plugin.publishing.ivy
 
+import nebula.plugin.publishing.publications.ShadowJarPlugin
 import nebula.plugin.publishing.publications.SpringBootJarPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -31,6 +32,7 @@ class IvyPublishPlugin implements Plugin<Project> {
         project.plugins.apply IvyRemovePlatformDependenciesPlugin
         project.plugins.apply IvyRemoveInvalidDependenciesPlugin
         project.plugins.apply SpringBootJarPlugin
+        project.plugins.apply ShadowJarPlugin
 
     }
 }

--- a/src/main/groovy/nebula/plugin/publishing/maven/MavenPublishPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/publishing/maven/MavenPublishPlugin.groovy
@@ -15,6 +15,7 @@
  */
 package nebula.plugin.publishing.maven
 
+import nebula.plugin.publishing.publications.ShadowJarPlugin
 import nebula.plugin.publishing.publications.SpringBootJarPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -31,6 +32,7 @@ class MavenPublishPlugin implements Plugin<Project> {
             apply MavenManifestPlugin
             apply MavenScmPlugin
             apply SpringBootJarPlugin
+            apply ShadowJarPlugin
         }
     }
 }

--- a/src/main/groovy/nebula/plugin/publishing/maven/MavenPublishPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/publishing/maven/MavenPublishPlugin.groovy
@@ -15,6 +15,7 @@
  */
 package nebula.plugin.publishing.maven
 
+import nebula.plugin.publishing.publications.SpringBootJarPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
@@ -29,6 +30,7 @@ class MavenPublishPlugin implements Plugin<Project> {
             apply MavenDeveloperPlugin
             apply MavenManifestPlugin
             apply MavenScmPlugin
+            apply SpringBootJarPlugin
         }
     }
 }

--- a/src/main/groovy/nebula/plugin/publishing/publications/ShadowJarPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/publishing/publications/ShadowJarPlugin.groovy
@@ -1,0 +1,27 @@
+package nebula.plugin.publishing.publications
+
+import groovy.transform.CompileDynamic
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.jvm.tasks.Jar
+
+@CompileDynamic
+class ShadowJarPlugin implements Plugin<Project> {
+
+    @Override
+    void apply(Project project) {
+        project.afterEvaluate {
+            project.plugins.withId('com.github.johnrengelman.shadow') {
+                boolean jarTaskEnabled = project.tasks.findByName('jar').enabled
+                if(!jarTaskEnabled) {
+                    project.configurations {
+                        [apiElements, runtimeElements].each {
+                            it.outgoing.artifacts.removeIf { it.buildDependencies.getDependencies(null).contains(project.tasks.named('jar', Jar).get()) }
+                            it.outgoing.artifact(project.tasks.named('shadowJar', Jar).get())
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/groovy/nebula/plugin/publishing/publications/SpringBootJarPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/publishing/publications/SpringBootJarPlugin.groovy
@@ -1,0 +1,22 @@
+package nebula.plugin.publishing.publications
+
+import groovy.transform.CompileDynamic
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.jvm.tasks.Jar
+
+@CompileDynamic
+class SpringBootJarPlugin implements Plugin<Project> {
+
+    @Override
+    void apply(Project project) {
+        project.plugins.withId('org.springframework.boot') {
+            project.configurations {
+                [apiElements, runtimeElements].each {
+                    it.outgoing.artifacts.removeIf { it.buildDependencies.getDependencies(null).contains(project.tasks.named('jar', Jar).get()) }
+                    it.outgoing.artifact(project.tasks.named('bootJar', Jar).get())
+                }
+            }
+        }
+    }
+}

--- a/src/test/groovy/nebula/plugin/publishing/ivy/IvyNebulaShadowJarPublishPluginIntegrationSpec.groovy
+++ b/src/test/groovy/nebula/plugin/publishing/ivy/IvyNebulaShadowJarPublishPluginIntegrationSpec.groovy
@@ -1,0 +1,264 @@
+/*
+ * Copyright 2015-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nebula.plugin.publishing.ivy
+
+import nebula.test.IntegrationTestKitSpec
+
+class IvyNebulaShadowJarPublishPluginIntegrationSpec extends IntegrationTestKitSpec {
+    def setup() {
+        debug = true
+        keepFiles = true
+        buildFile << """\
+            plugins {
+                id 'nebula.ivy-publish'
+                id "com.github.johnrengelman.shadow" version "5.2.0"
+                id 'java'
+                id "nebula.info" version "5.2.0"
+                id "nebula.contacts" version "5.1.0"
+            }
+
+            contacts {
+                'nebula@example.test' {
+                    moniker 'Nebula'
+                }
+            }
+            version = '0.1.0'
+            group = 'test.nebula'
+
+            repositories {
+                mavenCentral()
+            }
+            
+            dependencies {
+               implementation 'com.google.guava:guava:19.0'
+            }
+            
+             publishing {
+                repositories {
+                    ivy {
+                        name 'distIvy'
+                        url project.file("\${project.buildDir}/distIvy").toURI().toURL()
+                    }
+                }
+            }
+            
+             jar {
+              enabled = false // this configuration is used to produce only the shadowed jar
+            }
+
+            jar.dependsOn shadowJar // this configuration is used to produce only the shadowed jar            
+        """.stripIndent()
+
+        settingsFile << '''\
+            rootProject.name = 'ivypublishingtest'
+        '''.stripIndent()
+    }
+
+    def 'publish shadow jar with proper Ivy descriptor - no classifier'() {
+        setup:
+        buildFile << """
+            shadowJar {
+                classifier null // this configuration is used to produce only the shadowed jar
+               relocate 'com.google', 'com.netflix.shading.google'
+            }
+"""
+
+        writeJavaSourceFile("""
+package demo;
+
+public class DemoApplication {
+    public static void main(String[] args) {
+        System.out.println(args);
+    }
+}
+
+""")
+        when:
+        def result = runTasks('shadowJar', 'publishNebulaIvyPublicationToDistIvyRepository')
+
+        then:
+        def root = new XmlSlurper().parse(new File(projectDir, 'build/distIvy/test.nebula/ivypublishingtest/0.1.0/ivy-0.1.0.xml'))
+        root.info.@organisation == 'test.nebula'
+        root.info.@module == 'ivypublishingtest'
+        root.info.@revision == '0.1.0'
+        root.info.@status == 'integration'
+        def artifact = root.publications.artifact[0]
+        artifact.@name == 'ivypublishingtest'
+        artifact.@type == 'jar'
+
+        def desc = root
+                .declareNamespace([nebula: 'http://netflix.com/build'])
+                .info[0].description[0]
+        desc.children().size() > 1
+        desc.'nebula:Implementation_Version' == '0.1.0'
+        desc.'nebula:Implementation_Title' == 'test.nebula#ivypublishingtest;0.1.0'
+        desc.'nebula:Module_Email' == 'nebula@example.test'
+
+        and:
+        assertDependency('com.google.guava', 'guava', '19.0', 'runtime->default')
+
+        when:
+        def jar = new File(projectDir, "build/libs/ivypublishingtest-0.1.0.jar")
+
+        then:
+        jar.exists()
+    }
+
+    def 'publish shadow jar with proper Ivy descriptor - with classifier'() {
+        setup:
+        buildFile << """
+            shadowJar {
+               classifier 'all' // this configuration is used to produce only the shadowed jar
+               relocate 'com.google', 'com.netflix.shading.google'
+            }
+"""
+
+        writeJavaSourceFile("""
+package demo;
+
+public class DemoApplication {
+    public static void main(String[] args) {
+        System.out.println(args);
+    }
+}
+
+""")
+        when:
+        def result = runTasks('shadowJar', 'publishNebulaIvyPublicationToDistIvyRepository')
+
+        then:
+        def root = new XmlSlurper().parse(new File(projectDir, 'build/distIvy/test.nebula/ivypublishingtest/0.1.0/ivy-0.1.0.xml'))
+        root.info.@organisation == 'test.nebula'
+        root.info.@module == 'ivypublishingtest'
+        root.info.@revision == '0.1.0'
+        root.info.@status == 'integration'
+        def artifact = root.publications.artifact[0]
+        artifact.@name == 'ivypublishingtest'
+        artifact.@type == 'jar'
+
+        def desc = root
+                .declareNamespace([nebula: 'http://netflix.com/build'])
+                .info[0].description[0]
+        desc.children().size() > 1
+        desc.'nebula:Implementation_Version' == '0.1.0'
+        desc.'nebula:Implementation_Title' == 'test.nebula#ivypublishingtest;0.1.0'
+        desc.'nebula:Module_Email' == 'nebula@example.test'
+
+        and:
+        assertDependency('com.google.guava', 'guava', '19.0', 'runtime->default')
+
+        when:
+        def jar = new File(projectDir, "build/libs/ivypublishingtest-0.1.0-all.jar")
+
+        then:
+        jar.exists()
+    }
+
+    def 'publish shadow jar with proper Ivy descriptor - no classifier - manipulate xml'() {
+        setup:
+        buildFile << """
+            shadowJar {
+                classifier null // this configuration is used to produce only the shadowed jar
+               relocate 'com.google', 'com.netflix.shading.google'
+            }
+
+            
+            afterEvaluate {
+             publishing {
+              publications {
+               // to remove shaded dependency from ivy.xml
+               withType(IvyPublication) {
+                descriptor.withXml {
+                 asNode()
+                   .dependencies
+                   .dependency
+                   .findAll {
+                    it.@name == "guava"
+                   }
+                   .each { it.parent().remove(it) }
+                }
+               }
+               // to remove shaded dependency from pom.xml
+               withType(MavenPublication) {
+                pom.withXml {
+                 asNode()
+                   .dependencies
+                   .dependency
+                   .findAll {
+                    it.artifactId.text() == "guava"
+                   }
+                   .each { it.parent().remove(it) }
+                }
+               }
+              }
+             }
+            } 
+"""
+
+        writeJavaSourceFile("""
+package demo;
+
+public class DemoApplication {
+    public static void main(String[] args) {
+        System.out.println(args);
+    }
+}
+
+""")
+        when:
+        def result = runTasks('shadowJar', 'publishNebulaIvyPublicationToDistIvyRepository')
+
+        then:
+        def root = new XmlSlurper().parse(new File(projectDir, 'build/distIvy/test.nebula/ivypublishingtest/0.1.0/ivy-0.1.0.xml'))
+        root.info.@organisation == 'test.nebula'
+        root.info.@module == 'ivypublishingtest'
+        root.info.@revision == '0.1.0'
+        root.info.@status == 'integration'
+        def artifact = root.publications.artifact[0]
+        artifact.@name == 'ivypublishingtest'
+        artifact.@type == 'jar'
+
+        def desc = root
+                .declareNamespace([nebula: 'http://netflix.com/build'])
+                .info[0].description[0]
+        desc.children().size() > 1
+        desc.'nebula:Implementation_Version' == '0.1.0'
+        desc.'nebula:Implementation_Title' == 'test.nebula#ivypublishingtest;0.1.0'
+        desc.'nebula:Module_Email' == 'nebula@example.test'
+
+        and:
+        !findDependency('com.google.guava', 'guava')
+
+        when:
+        def jar = new File(projectDir, "build/libs/ivypublishingtest-0.1.0.jar")
+
+        then:
+        jar.exists()
+    }
+
+    def findDependency(String org, String name) {
+        def dependencies = new XmlSlurper().parse(new File(projectDir, 'build/distIvy/test.nebula/ivypublishingtest/0.1.0/ivy-0.1.0.xml')).dependencies.dependency
+        return dependencies.find { it.@name == name && it.@org == org }
+    }
+
+    boolean assertDependency(String org, String name, String rev, String conf = null) {
+        def found = findDependency(org, name)
+        assert found
+        assert found.@rev == rev
+        assert !conf || found.@conf == conf
+        found
+    }
+}

--- a/src/test/groovy/nebula/plugin/publishing/ivy/IvyNebulaSpringBootPublishPluginIntegrationSpec.groovy
+++ b/src/test/groovy/nebula/plugin/publishing/ivy/IvyNebulaSpringBootPublishPluginIntegrationSpec.groovy
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2015-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nebula.plugin.publishing.ivy
+
+import nebula.test.IntegrationTestKitSpec
+
+class IvyNebulaSpringBootPublishPluginIntegrationSpec extends IntegrationTestKitSpec {
+    def setup() {
+        debug = true
+        keepFiles = true
+        buildFile << """\
+            plugins {
+                id 'nebula.ivy-publish'
+                id 'org.springframework.boot' version '2.2.4.RELEASE'
+                id 'io.spring.dependency-management' version '1.0.9.RELEASE'
+                id 'java'
+                id "nebula.info" version "5.2.0"
+                id "nebula.contacts" version "5.1.0"
+            }
+
+            contacts {
+                'nebula@example.test' {
+                    moniker 'Nebula'
+                }
+            }
+            version = '0.1.0'
+            group = 'test.nebula'
+
+            repositories {
+                mavenCentral()
+            }
+            
+            dependencies {
+                implementation 'org.springframework.boot:spring-boot-starter-web'
+                runtimeOnly 'org.postgresql:postgresql'
+                testImplementation('org.springframework.boot:spring-boot-starter-test') {
+                exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
+                }
+            }
+            
+             publishing {
+                repositories {
+                    ivy {
+                        name 'distIvy'
+                        url project.file("\${project.buildDir}/distIvy").toURI().toURL()
+                    }
+                }
+            }
+        """.stripIndent()
+
+        settingsFile << '''\
+            rootProject.name = 'ivypublishingtest'
+        '''.stripIndent()
+    }
+
+    def 'publish spring boot jar with proper Ivy descriptor'() {
+        setup:
+        writeJavaSourceFile("""
+package demo;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+        @SpringBootApplication
+public class DemoApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(DemoApplication.class, args);
+    }
+
+}
+
+""")
+        when:
+        def result = runTasks('bootJar', 'publishNebulaIvyPublicationToDistIvyRepository')
+
+        then:
+        def root = new XmlSlurper().parse(new File(projectDir, 'build/distIvy/test.nebula/ivypublishingtest/0.1.0/ivy-0.1.0.xml'))
+        root.info.@organisation == 'test.nebula'
+        root.info.@module == 'ivypublishingtest'
+        root.info.@revision == '0.1.0'
+        root.info.@status == 'integration'
+        def artifact = root.publications.artifact[0]
+        artifact.@name == 'ivypublishingtest'
+        artifact.@type == 'jar'
+
+        def desc = root
+                .declareNamespace([nebula: 'http://netflix.com/build'])
+                .info[0].description[0]
+        desc.children().size() > 1
+        desc.'nebula:Implementation_Version' == '0.1.0'
+        desc.'nebula:Implementation_Title' == 'test.nebula#ivypublishingtest;0.1.0'
+        desc.'nebula:Module_Email' == 'nebula@example.test'
+
+        and:
+        assertDependency('org.springframework.boot', 'spring-boot-starter-web', '2.2.4.RELEASE', 'runtime->default')
+        assertDependency('org.postgresql', 'postgresql', '42.2.9', 'runtime->default')
+
+        when:
+        def jar = new File(projectDir, "build/libs/ivypublishingtest-0.1.0.jar")
+
+        then:
+        jar.exists()
+    }
+
+    boolean assertDependency(String org, String name, String rev, String conf = null) {
+        def dependencies = new XmlSlurper().parse(new File(projectDir, 'build/distIvy/test.nebula/ivypublishingtest/0.1.0/ivy-0.1.0.xml')).dependencies.dependency
+        def found = dependencies.find { it.@name == name && it.@org == org }
+        assert found
+        assert found.@rev == rev
+        assert !conf || found.@conf == conf
+        found
+    }
+
+
+}

--- a/src/test/groovy/nebula/plugin/publishing/maven/MavenNebulaShadowJarPublishPluginIntegrationSpec.groovy
+++ b/src/test/groovy/nebula/plugin/publishing/maven/MavenNebulaShadowJarPublishPluginIntegrationSpec.groovy
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2015-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nebula.plugin.publishing.maven
+
+import nebula.test.IntegrationTestKitSpec
+
+class MavenNebulaShadowJarPublishPluginIntegrationSpec extends IntegrationTestKitSpec {
+    def setup() {
+        debug = true
+        keepFiles = true
+        buildFile << """\
+            plugins {
+                id 'nebula.maven-publish'
+                id "com.github.johnrengelman.shadow" version "5.2.0"
+                id 'java'
+                id "nebula.info" version "5.2.0"
+                id "nebula.contacts" version "5.1.0"
+            }
+            
+            contacts {
+                'nebula@example.test' {
+                    moniker 'Nebula'
+                }
+            }
+            version = '0.1.0'
+            group = 'test.nebula'
+
+            repositories {
+                mavenCentral()
+            }
+            
+            dependencies {
+               implementation 'com.google.guava:guava:19.0'
+            }
+            
+            publishing {
+                repositories {
+                    maven {
+                        name = 'testLocal'
+                        url = 'testrepo'
+                    }
+                }
+            }
+            
+            jar {
+              enabled = false // this configuration is used to produce only the shadowed jar
+            }
+
+            jar.dependsOn shadowJar // this configuration is used to produce only the shadowed jar
+
+        """.stripIndent()
+
+        settingsFile << '''\
+            rootProject.name = 'mavenpublishingtest'
+        '''.stripIndent()
+    }
+
+    def 'publish shadow jar with proper POM - no classifier'() {
+        setup:
+        buildFile << """
+            shadowJar {
+                classifier null // this configuration is used to produce only the shadowed jar
+               relocate 'com.google', 'com.netflix.shading.google'
+            }
+"""
+        writeJavaSourceFile("""
+package demo;
+
+public class DemoApplication {
+
+    public static void main(String[] args) {
+        System.out.println(args);
+    }
+
+}
+
+""")
+        when:
+        def result = runTasks('shadowJar', 'publishNebulaPublicationToTestLocalRepository')
+
+        then:
+        def pom = new XmlSlurper().parse(new File(projectDir, 'build/publications/nebula/pom-default.xml'))
+        pom.version == '0.1.0'
+        pom.developers.developer[0].name == 'Nebula'
+        pom.properties.nebula_Module_Owner == 'nebula@example.test'
+        pom.url != null
+
+        when:
+        def dependencies = pom.dependencies.dependency
+        def guava = dependencies.find { it.artifactId == 'guava' }
+
+        then:
+        guava.version == '19.0'
+
+        when:
+        def jar = new File(projectDir, "build/libs/mavenpublishingtest-0.1.0.jar")
+
+        then:
+        jar.exists()
+    }
+
+
+    def 'publish shadow jar with proper POM - with classifier'() {
+        setup:
+        buildFile << """
+            shadowJar {
+                classifier 'all' 
+               relocate 'com.google', 'com.netflix.shading.google'
+            }
+"""
+        writeJavaSourceFile("""
+package demo;
+
+public class DemoApplication {
+
+    public static void main(String[] args) {
+        System.out.println(args);
+    }
+
+}
+
+""")
+        when:
+        def result = runTasks('shadowJar', 'publishNebulaPublicationToTestLocalRepository')
+
+        then:
+        def pom = new XmlSlurper().parse(new File(projectDir, 'build/publications/nebula/pom-default.xml'))
+        pom.version == '0.1.0'
+        pom.developers.developer[0].name == 'Nebula'
+        pom.properties.nebula_Module_Owner == 'nebula@example.test'
+        pom.url != null
+
+        when:
+        def dependencies = pom.dependencies.dependency
+        def guava = dependencies.find { it.artifactId == 'guava' }
+
+        then:
+        guava.version == '19.0'
+
+        when:
+        def jar = new File(projectDir, "build/libs/mavenpublishingtest-0.1.0-all.jar")
+
+        then:
+        jar.exists()
+    }
+
+    def 'publish shadow jar with proper POM - no classifier - manipulate xml'() {
+        setup:
+        buildFile << """
+            shadowJar {
+                classifier null // this configuration is used to produce only the shadowed jar
+               relocate 'com.google', 'com.netflix.shading.google'
+            }
+            
+            afterEvaluate {
+             publishing {
+              publications {
+               // to remove shaded dependency from ivy.xml
+               withType(IvyPublication) {
+                descriptor.withXml {
+                 asNode()
+                   .dependencies
+                   .dependency
+                   .findAll {
+                    it.@name == "guava"
+                   }
+                   .each { it.parent().remove(it) }
+                }
+               }
+               // to remove shaded dependency from pom.xml
+               withType(MavenPublication) {
+                pom.withXml {
+                 asNode()
+                   .dependencies
+                   .dependency
+                   .findAll {
+                    it.artifactId.text() == "guava"
+                   }
+                   .each { it.parent().remove(it) }
+                }
+               }
+              }
+             }
+            }            
+"""
+        writeJavaSourceFile("""
+package demo;
+
+public class DemoApplication {
+
+    public static void main(String[] args) {
+        System.out.println(args);
+    }
+
+}
+
+""")
+        when:
+        def result = runTasks('shadowJar', 'publishNebulaPublicationToTestLocalRepository')
+
+        then:
+        def pom = new XmlSlurper().parse(new File(projectDir, 'build/publications/nebula/pom-default.xml'))
+        pom.version == '0.1.0'
+        pom.developers.developer[0].name == 'Nebula'
+        pom.properties.nebula_Module_Owner == 'nebula@example.test'
+        pom.url != null
+
+        when:
+        def dependencies = pom.dependencies.dependency
+        def guava = dependencies.find { it.artifactId == 'guava' }
+
+        then:
+        !guava
+
+        when:
+        def jar = new File(projectDir, "build/libs/mavenpublishingtest-0.1.0.jar")
+
+        then:
+        jar.exists()
+    }
+
+}

--- a/src/test/groovy/nebula/plugin/publishing/maven/MavenNebulaSpringBootPublishPluginIntegrationSpec.groovy
+++ b/src/test/groovy/nebula/plugin/publishing/maven/MavenNebulaSpringBootPublishPluginIntegrationSpec.groovy
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2015-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nebula.plugin.publishing.maven
+
+import nebula.test.IntegrationTestKitSpec
+
+class MavenNebulaSpringBootPublishPluginIntegrationSpec  extends IntegrationTestKitSpec {
+    def setup() {
+        debug = true
+        keepFiles = true
+        buildFile << """\
+            plugins {
+                id 'nebula.maven-publish'
+                id 'org.springframework.boot' version '2.2.4.RELEASE'
+                id 'io.spring.dependency-management' version '1.0.9.RELEASE'
+                id 'java'
+                id "nebula.info" version "5.2.0"
+                id "nebula.contacts" version "5.1.0"
+            }
+
+            contacts {
+                'nebula@example.test' {
+                    moniker 'Nebula'
+                }
+            }
+            version = '0.1.0'
+            group = 'test.nebula'
+
+            repositories {
+                mavenCentral()
+            }
+            
+            dependencies {
+                implementation 'org.springframework.boot:spring-boot-starter-web'
+                runtimeOnly 'org.postgresql:postgresql'
+                testImplementation('org.springframework.boot:spring-boot-starter-test') {
+                exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
+                }
+            }
+            
+            publishing {
+                repositories {
+                    maven {
+                        name = 'testLocal'
+                        url = 'testrepo'
+                    }
+                }
+            }
+        """.stripIndent()
+
+        settingsFile << '''\
+            rootProject.name = 'mavenpublishingtest'
+        '''.stripIndent()
+    }
+
+    def 'publish spring boot jar with proper POM'() {
+        setup:
+        writeJavaSourceFile("""
+package demo;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+        @SpringBootApplication
+public class DemoApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(DemoApplication.class, args);
+    }
+
+}
+
+""")
+        when:
+        def result = runTasks('bootJar', 'publishNebulaPublicationToTestLocalRepository')
+
+        then:
+        def pom = new XmlSlurper().parse(new File(projectDir, 'build/publications/nebula/pom-default.xml'))
+        pom.version == '0.1.0'
+        pom.developers.developer[0].name == 'Nebula'
+        pom.properties.nebula_Module_Owner == 'nebula@example.test'
+        pom.url != null
+
+        when:
+        def dependencies = pom.dependencies.dependency
+        def spring = dependencies.find { it.artifactId == 'spring-boot-starter-web' }
+
+        then:
+        spring.version == '2.2.4.RELEASE'
+
+        when:
+        def jar = new File(projectDir, "build/libs/mavenpublishingtest-0.1.0.jar")
+
+        then:
+        jar.exists()
+    }
+
+
+}


### PR DESCRIPTION
Gradle 6.2 nightly introduced a change creating the following error:

```
xecution failed for task ':publishNebulaPublicationToMavenLocal'.
> Failed to publish publication 'nebula' to repository 'mavenLocal'
   > Artifact demo-0.0.1-SNAPSHOT.jar wasn't produced by this build.
```

I was looking at https://github.com/gradle/gradle/blob/master/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/MavenNormalizedPublication.java#L86 and https://github.com/gradle/gradle/blob/master/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/IvyNormalizedPublication.java#L62 which have this new behavior for checking if a JAR can be published or not.

I saw that sources jar were just fine but not the main jar… after some minutes realized that this checks for the jar task enabled at somepoint (https://github.com/gradle/gradle/blob/master/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java#L353). However, the spring boot gradle plugin introduces the bootJar https://github.com/spring-projects/spring-boot/blob/master/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/tasks/bundling/BootJar.java and disable the original JAR task form gradle https://github.com/spring-projects/spring-boot/blob/cbacab5e265caf92a307373e73d9a5cba9da9873/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/JavaPluginAction.java#L78

 It seems like the problem is when publications are configured to do `components.java` (as we do in nebula publishing -> https://github.com/nebula-plugins/nebula-publishing-plugin/blob/master/src/main/groovy/nebula/plugin/publishing/maven/MavenNebulaPublishPlugin.groovy#L49) and the `jar` task is disabled so the main artifact is generated by another `Jar` task such as `BootJar` or `ShadowJar`. When that happens, the main artifact is generated by the 3rd party plugin but gradle is expecting the jar to come from the main `Jar` task which is disabled at that point.

This causes the build to fail.

The change was introduced in https://github.com/gradle/gradle/commit/55f7c7d5016e90407c6e3ced071c18246ee367e5

There is a workaround for the spring boot case:

```
configurations {
	[apiElements, runtimeElements].each {
		it.outgoing.artifacts.removeIf { it.buildDependencies.getDependencies(null).contains(jar) }
		it.outgoing.artifact(bootJar)
	}
}
```

 While spring boot docs suggest to configure publications as follows:

```
publishing {
	publications {
		bootJava(MavenPublication) {
			artifact bootJar
		}
	}
} 
```

Which works… I suspect people might be doing things similar to what we do in nebula. We apply some opinions to configure the publications based on `components.java` and not a particular artifact coming from a task.

This work is to apply the workaround when spring boot plugin is applied in the project

WE might want to do something similar for folks using shadow plugin and replacing the main artifact (jar from `Jar` task) with Shadow's