### PR TITLE
Shadow publication enhancements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,11 @@ gradlePlugin {
             implementationClass = 'nebula.plugin.publishing.maven.MavenPublishPlugin'
         }
 
+        mavenShadowPublish {
+            id = 'nebula.maven-shadow-publish'
+            implementationClass = 'nebula.plugin.publishing.maven.MavenShadowPublishPlugin'
+        }
+
         mavenResolvedDependencies {
             id = 'nebula.maven-resolved-dependencies'
             implementationClass = 'nebula.plugin.publishing.maven.MavenResolvedDependenciesPlugin'
@@ -132,6 +137,11 @@ gradlePlugin {
             implementationClass = 'nebula.plugin.publishing.ivy.IvyPublishPlugin'
         }
 
+        ivyShadowPublish {
+            id = 'nebula.ivy-shadow-publish'
+            implementationClass = 'nebula.plugin.publishing.ivy.IvyShadowPublishPlugin'
+        }
+
         ivyResolvedDependencies {
             id = 'nebula.ivy-resolved-dependencies'
             implementationClass = 'nebula.plugin.publishing.ivy.IvyResolvedDependenciesPlugin'
@@ -160,11 +170,6 @@ gradlePlugin {
         sourceJar {
             id = 'nebula.source-jar'
             implementationClass = 'nebula.plugin.publishing.publications.SourceJarPlugin'
-        }
-
-        shadowJar {
-            id = 'nebula.shadow-jar'
-            implementationClass = 'nebula.plugin.publishing.publications.ShadowJarPlugin'
         }
 
         springBootJar {
@@ -228,6 +233,13 @@ pluginBundle {
             tags = ['nebula', 'publish', 'maven']
         }
 
+        mavenShadowPublish {
+            id = 'nebula.maven-shadow-publish'
+            displayName = 'Nebula Shadow Publishing plugin'
+            description = 'Configures project to use shadowJar artifact instead of jar artifact when users want to replace the jar task'
+            tags = ['nebula', 'publish', 'shadow']
+        }
+
         mavenResolvedDependencies {
             id = 'nebula.maven-resolved-dependencies'
             displayName = 'Nebula Maven Resolved Dependencies Plugin'
@@ -268,6 +280,13 @@ pluginBundle {
             displayName = 'Nebula Ivy Publish Plugin'
             description = 'Applies our opinions for ivy publications'
             tags = ['nebula', 'publish', 'ivy']
+        }
+
+        ivyShadowPublish {
+            id = 'nebula.ivy-shadow-publish'
+            displayName = 'Nebula Shadow Publishing plugin'
+            description = 'Configures project to use shadowJar artifact instead of jar artifact when users want to replace the jar task'
+            tags = ['nebula', 'publish', 'shadow']
         }
 
         ivyNebulaPublish {
@@ -324,13 +343,6 @@ pluginBundle {
             displayName = 'Nebula Spring Boot Jar Publishing plugin'
             description = 'Configures project to use bootJar artifact instead of jar artifact'
             tags = ['nebula', 'publish', 'spring-boot']
-        }
-
-        shadowJar {
-            id = 'nebula.shadow-jar'
-            displayName = 'Nebula Shadow Jar Publishing plugin'
-            description = 'Configures project to use shadowJar artifact instead of jar artifact when users want to replace the jar task'
-            tags = ['nebula', 'publish', 'shadow']
         }
 
         testJar {

--- a/src/main/groovy/nebula/plugin/publishing/ivy/IvyPublishPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/publishing/ivy/IvyPublishPlugin.groovy
@@ -15,7 +15,6 @@
  */
 package nebula.plugin.publishing.ivy
 
-import nebula.plugin.publishing.publications.ShadowJarPlugin
 import nebula.plugin.publishing.publications.SpringBootJarPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -31,8 +30,8 @@ class IvyPublishPlugin implements Plugin<Project> {
         project.plugins.apply IvyManifestPlugin
         project.plugins.apply IvyRemovePlatformDependenciesPlugin
         project.plugins.apply IvyRemoveInvalidDependenciesPlugin
+        project.plugins.apply IvyShadowPublishPlugin
         project.plugins.apply SpringBootJarPlugin
-        project.plugins.apply ShadowJarPlugin
 
     }
 }

--- a/src/main/groovy/nebula/plugin/publishing/ivy/IvyShadowPublishPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/publishing/ivy/IvyShadowPublishPlugin.groovy
@@ -1,14 +1,10 @@
 package nebula.plugin.publishing.ivy
 
 import groovy.transform.CompileDynamic
-import org.gradle.api.Action
+import nebula.plugin.publishing.publications.ShadowJarPublicationConfigurer
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.Task
-import org.gradle.api.publish.PublicationContainer
-import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.ivy.IvyPublication
-import org.gradle.jvm.tasks.Jar
 
 @CompileDynamic
 class IvyShadowPublishPlugin implements Plugin<Project> {
@@ -16,32 +12,7 @@ class IvyShadowPublishPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
         project.afterEvaluate {
-            project.plugins.withId('com.github.johnrengelman.shadow') {
-                Task shadowJarTask = project.tasks.findByName('shadowJar')
-                boolean jarTaskEnabled = project.tasks.findByName('jar').enabled
-                if(!jarTaskEnabled) {
-                    project.configurations {
-                        [apiElements, runtimeElements].each {
-                            if(shadowJarTask) {
-                                it.outgoing.artifacts.removeIf { it.buildDependencies.getDependencies(null).contains(project.tasks.named('jar', Jar).get()) }
-                                it.outgoing.artifact(shadowJarTask)
-                            }
-                        }
-                    }
-                } else {
-                    PublishingExtension publishing = project.extensions.getByType(PublishingExtension)
-                    publishing.publications(new Action<PublicationContainer>() {
-                        @Override
-                        void execute(PublicationContainer publications) {
-                            if(shadowJarTask) {
-                                publications.withType(IvyPublication) { IvyPublication publication ->
-                                    publication.artifact(shadowJarTask)
-                                }
-                            }
-                        }
-                    })
-                }
-            }
+            ShadowJarPublicationConfigurer.configure(project, IvyPublication)
         }
     }
 }

--- a/src/main/groovy/nebula/plugin/publishing/maven/MavenPublishPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/publishing/maven/MavenPublishPlugin.groovy
@@ -15,7 +15,6 @@
  */
 package nebula.plugin.publishing.maven
 
-import nebula.plugin.publishing.publications.ShadowJarPlugin
 import nebula.plugin.publishing.publications.SpringBootJarPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -31,8 +30,8 @@ class MavenPublishPlugin implements Plugin<Project> {
             apply MavenDeveloperPlugin
             apply MavenManifestPlugin
             apply MavenScmPlugin
+            apply MavenShadowPublishPlugin
             apply SpringBootJarPlugin
-            apply ShadowJarPlugin
         }
     }
 }

--- a/src/main/groovy/nebula/plugin/publishing/maven/MavenShadowPublishPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/publishing/maven/MavenShadowPublishPlugin.groovy
@@ -1,0 +1,47 @@
+package nebula.plugin.publishing.maven
+
+import groovy.transform.CompileDynamic
+import org.gradle.api.Action
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.publish.PublicationContainer
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.jvm.tasks.Jar
+
+@CompileDynamic
+class MavenShadowPublishPlugin implements Plugin<Project> {
+
+    @Override
+    void apply(Project project) {
+        project.afterEvaluate {
+            project.plugins.withId('com.github.johnrengelman.shadow') {
+                Task shadowJarTask = project.tasks.findByName('shadowJar')
+                boolean jarTaskEnabled = project.tasks.findByName('jar').enabled
+                if(!jarTaskEnabled) {
+                    project.configurations {
+                        [apiElements, runtimeElements].each {
+                            if(shadowJarTask) {
+                                it.outgoing.artifacts.removeIf { it.buildDependencies.getDependencies(null).contains(project.tasks.named('jar', Jar).get()) }
+                                it.outgoing.artifact(shadowJarTask)
+                            }
+                        }
+                    }
+                } else {
+                    PublishingExtension publishing = project.extensions.getByType(PublishingExtension)
+                    publishing.publications(new Action<PublicationContainer>() {
+                        @Override
+                        void execute(PublicationContainer publications) {
+                            if(shadowJarTask) {
+                                publications.withType(MavenPublication) { MavenPublication publication ->
+                                    publication.artifact(shadowJarTask)
+                                }
+                            }
+                        }
+                    })
+                }
+            }
+        }
+    }
+}

--- a/src/main/groovy/nebula/plugin/publishing/maven/MavenShadowPublishPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/publishing/maven/MavenShadowPublishPlugin.groovy
@@ -1,14 +1,10 @@
 package nebula.plugin.publishing.maven
 
 import groovy.transform.CompileDynamic
-import org.gradle.api.Action
+import nebula.plugin.publishing.publications.ShadowJarPublicationConfigurer
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.Task
-import org.gradle.api.publish.PublicationContainer
-import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
-import org.gradle.jvm.tasks.Jar
 
 @CompileDynamic
 class MavenShadowPublishPlugin implements Plugin<Project> {
@@ -16,32 +12,7 @@ class MavenShadowPublishPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
         project.afterEvaluate {
-            project.plugins.withId('com.github.johnrengelman.shadow') {
-                Task shadowJarTask = project.tasks.findByName('shadowJar')
-                boolean jarTaskEnabled = project.tasks.findByName('jar').enabled
-                if(!jarTaskEnabled) {
-                    project.configurations {
-                        [apiElements, runtimeElements].each {
-                            if(shadowJarTask) {
-                                it.outgoing.artifacts.removeIf { it.buildDependencies.getDependencies(null).contains(project.tasks.named('jar', Jar).get()) }
-                                it.outgoing.artifact(shadowJarTask)
-                            }
-                        }
-                    }
-                } else {
-                    PublishingExtension publishing = project.extensions.getByType(PublishingExtension)
-                    publishing.publications(new Action<PublicationContainer>() {
-                        @Override
-                        void execute(PublicationContainer publications) {
-                            if(shadowJarTask) {
-                                publications.withType(MavenPublication) { MavenPublication publication ->
-                                    publication.artifact(shadowJarTask)
-                                }
-                            }
-                        }
-                    })
-                }
-            }
+            ShadowJarPublicationConfigurer.configure(project, MavenPublication)
         }
     }
 }

--- a/src/main/groovy/nebula/plugin/publishing/publications/ShadowJarPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/publishing/publications/ShadowJarPlugin.groovy
@@ -1,9 +1,14 @@
 package nebula.plugin.publishing.publications
 
 import groovy.transform.CompileDynamic
+import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.publish.PublicationContainer
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.ivy.IvyPublication
+import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.jvm.tasks.Jar
 
 @CompileDynamic
@@ -24,6 +29,19 @@ class ShadowJarPlugin implements Plugin<Project> {
                             }
                         }
                     }
+                } else {
+                    PublishingExtension publishing = project.extensions.getByType(PublishingExtension)
+                    publishing.publications(new Action<PublicationContainer>() {
+                        @Override
+                        void execute(PublicationContainer publications) {
+                            publications.withType(MavenPublication) { MavenPublication publication ->
+                                publication.artifact(project.tasks.findByName('shadowJar'))
+                            }
+                            publications.withType(IvyPublication) { IvyPublication publication ->
+                                publication.artifact(project.tasks.findByName('shadowJar'))
+                            }
+                        }
+                    })
                 }
             }
         }

--- a/src/main/groovy/nebula/plugin/publishing/publications/ShadowJarPublicationConfigurer.groovy
+++ b/src/main/groovy/nebula/plugin/publishing/publications/ShadowJarPublicationConfigurer.groovy
@@ -1,0 +1,45 @@
+package nebula.plugin.publishing.publications
+
+import groovy.transform.CompileDynamic
+import org.gradle.api.Action
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.publish.Publication
+import org.gradle.api.publish.PublicationContainer
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.jvm.tasks.Jar
+
+@CompileDynamic
+class ShadowJarPublicationConfigurer {
+
+    static configure(Project project, Class<? extends Publication> publicationClass) {
+        project.plugins.withId('com.github.johnrengelman.shadow') {
+            Task shadowJarTask = project.tasks.findByName('shadowJar')
+            boolean jarTaskEnabled = project.tasks.findByName('jar').enabled
+            if (!jarTaskEnabled) {
+                project.configurations {
+                    [apiElements, runtimeElements].each {
+                        if (shadowJarTask) {
+                            it.outgoing.artifacts.removeIf { it.buildDependencies.getDependencies(null).contains(project.tasks.named('jar', Jar).get()) }
+                            it.outgoing.artifact(shadowJarTask)
+                        }
+                    }
+                }
+            } else {
+                PublishingExtension publishing = project.extensions.getByType(PublishingExtension)
+                publishing.publications(new Action<PublicationContainer>() {
+                    @Override
+                    void execute(PublicationContainer publications) {
+                        if (shadowJarTask) {
+                            publications.withType(publicationClass) { publication ->
+                                publication.artifact(shadowJarTask)
+                            }
+                        }
+                    }
+                })
+            }
+        }
+
+    }
+}

--- a/src/test/groovy/nebula/plugin/publishing/ivy/IvyNebulaShadowJarPublishPluginIntegrationSpec.groovy
+++ b/src/test/groovy/nebula/plugin/publishing/ivy/IvyNebulaShadowJarPublishPluginIntegrationSpec.groovy
@@ -54,10 +54,6 @@ class IvyNebulaShadowJarPublishPluginIntegrationSpec extends IntegrationTestKitS
                     }
                 }
             }
-            
-             jar {
-              enabled = false // this configuration is used to produce only the shadowed jar
-            }
 
             jar.dependsOn shadowJar // this configuration is used to produce only the shadowed jar            
         """.stripIndent()
@@ -70,6 +66,10 @@ class IvyNebulaShadowJarPublishPluginIntegrationSpec extends IntegrationTestKitS
     def 'publish shadow jar with proper Ivy descriptor - no classifier'() {
         setup:
         buildFile << """
+            jar {
+              enabled = false // this configuration is used to produce only the shadowed jar
+            }
+            
             shadowJar {
                 classifier null // this configuration is used to produce only the shadowed jar
                relocate 'com.google', 'com.netflix.shading.google'
@@ -111,15 +111,35 @@ public class DemoApplication {
         assertDependency('com.google.guava', 'guava', '19.0', 'runtime->default')
 
         when:
-        def jar = new File(projectDir, "build/libs/ivypublishingtest-0.1.0.jar")
+        and:
+        fileWasPublished('ivypublishingtest-0.1.0.jar')
+        fileWasPublished('ivypublishingtest-0.1.0.jar.sha1')
+        fileWasPublished('ivypublishingtest-0.1.0.jar.sha256')
+        fileWasPublished('ivypublishingtest-0.1.0.jar.sha512')
 
-        then:
-        jar.exists()
+        !fileWasPublished('ivypublishingtest-0.1.0-all.jar')
+        !fileWasPublished('ivypublishingtest-0.1.0-all.jar.sha1')
+        !fileWasPublished('ivypublishingtest-0.1.0-all.jar.sha256')
+        !fileWasPublished('ivypublishingtest-0.1.0-all.jar.sha512')
+
+        fileWasPublished('ivypublishingtest-0.1.0.module')
+        fileWasPublished('ivypublishingtest-0.1.0.module.sha1')
+        fileWasPublished('ivypublishingtest-0.1.0.module.sha256')
+        fileWasPublished('ivypublishingtest-0.1.0.module.sha512')
+
+        fileWasPublished('ivy-0.1.0.xml')
+        fileWasPublished('ivy-0.1.0.xml.sha1')
+        fileWasPublished('ivy-0.1.0.xml.sha256')
+        fileWasPublished('ivy-0.1.0.xml.sha512')
     }
 
     def 'publish shadow jar with proper Ivy descriptor - with classifier'() {
         setup:
         buildFile << """
+            jar {
+              enabled = false // this configuration is used to produce only the shadowed jar
+            }
+            
             shadowJar {
                classifier 'all' // this configuration is used to produce only the shadowed jar
                relocate 'com.google', 'com.netflix.shading.google'
@@ -160,16 +180,35 @@ public class DemoApplication {
         and:
         assertDependency('com.google.guava', 'guava', '19.0', 'runtime->default')
 
-        when:
-        def jar = new File(projectDir, "build/libs/ivypublishingtest-0.1.0-all.jar")
+        and:
+        !fileWasPublished('ivypublishingtest-0.1.0.jar')
+        !fileWasPublished('ivypublishingtest-0.1.0.jar.sha1')
+        !fileWasPublished('ivypublishingtest-0.1.0.jar.sha256')
+        !fileWasPublished('ivypublishingtest-0.1.0.jar.sha512')
 
-        then:
-        jar.exists()
+        fileWasPublished('ivypublishingtest-0.1.0-all.jar')
+        fileWasPublished('ivypublishingtest-0.1.0-all.jar.sha1')
+        fileWasPublished('ivypublishingtest-0.1.0-all.jar.sha256')
+        fileWasPublished('ivypublishingtest-0.1.0-all.jar.sha512')
+
+        fileWasPublished('ivypublishingtest-0.1.0.module')
+        fileWasPublished('ivypublishingtest-0.1.0.module.sha1')
+        fileWasPublished('ivypublishingtest-0.1.0.module.sha256')
+        fileWasPublished('ivypublishingtest-0.1.0.module.sha512')
+
+        fileWasPublished('ivy-0.1.0.xml')
+        fileWasPublished('ivy-0.1.0.xml.sha1')
+        fileWasPublished('ivy-0.1.0.xml.sha256')
+        fileWasPublished('ivy-0.1.0.xml.sha512')
     }
 
     def 'publish shadow jar with proper Ivy descriptor - no classifier - manipulate xml'() {
         setup:
         buildFile << """
+            jar {
+              enabled = false // this configuration is used to produce only the shadowed jar
+            }
+            
             shadowJar {
                 classifier null // this configuration is used to produce only the shadowed jar
                relocate 'com.google', 'com.netflix.shading.google'
@@ -242,11 +281,123 @@ public class DemoApplication {
         and:
         !findDependency('com.google.guava', 'guava')
 
+        and:
+        fileWasPublished('ivypublishingtest-0.1.0.jar')
+        fileWasPublished('ivypublishingtest-0.1.0.jar.sha1')
+        fileWasPublished('ivypublishingtest-0.1.0.jar.sha256')
+        fileWasPublished('ivypublishingtest-0.1.0.jar.sha512')
+
+        !fileWasPublished('ivypublishingtest-0.1.0-shadow.jar')
+        !fileWasPublished('ivypublishingtest-0.1.0-shadow.jar.sha1')
+        !fileWasPublished('ivypublishingtest-0.1.0-shadow.jar.sha256')
+        !fileWasPublished('ivypublishingtest-0.1.0-shadow.jar.sha512')
+
+        fileWasPublished('ivypublishingtest-0.1.0.module')
+        fileWasPublished('ivypublishingtest-0.1.0.module.sha1')
+        fileWasPublished('ivypublishingtest-0.1.0.module.sha256')
+        fileWasPublished('ivypublishingtest-0.1.0.module.sha512')
+
+        fileWasPublished('ivy-0.1.0.xml')
+        fileWasPublished('ivy-0.1.0.xml.sha1')
+        fileWasPublished('ivy-0.1.0.xml.sha256')
+        fileWasPublished('ivy-0.1.0.xml.sha512')
+    }
+
+    def 'publish shadow jar with proper Ivy descriptor - with classifier and jar enabled - manipulate xml'() {
+        setup:
+        buildFile << """
+            shadowJar {
+               classifier 'shadow' // this configuration is used to produce only the shadowed jar
+               relocate 'com.google', 'com.netflix.shading.google'
+            }
+
+            
+            afterEvaluate {
+             publishing {
+              publications {
+               // to remove shaded dependency from ivy.xml
+               withType(IvyPublication) {
+                descriptor.withXml {
+                 asNode()
+                   .dependencies
+                   .dependency
+                   .findAll {
+                    it.@name == "guava"
+                   }
+                   .each { it.parent().remove(it) }
+                }
+               }
+               // to remove shaded dependency from pom.xml
+               withType(MavenPublication) {
+                pom.withXml {
+                 asNode()
+                   .dependencies
+                   .dependency
+                   .findAll {
+                    it.artifactId.text() == "guava"
+                   }
+                   .each { it.parent().remove(it) }
+                }
+               }
+              }
+             }
+            } 
+"""
+
+        writeJavaSourceFile("""
+package demo;
+
+public class DemoApplication {
+    public static void main(String[] args) {
+        System.out.println(args);
+    }
+}
+
+""")
         when:
-        def jar = new File(projectDir, "build/libs/ivypublishingtest-0.1.0.jar")
+        def result = runTasks('shadowJar', 'publishNebulaIvyPublicationToDistIvyRepository')
 
         then:
-        jar.exists()
+        def root = new XmlSlurper().parse(new File(projectDir, 'build/distIvy/test.nebula/ivypublishingtest/0.1.0/ivy-0.1.0.xml'))
+        root.info.@organisation == 'test.nebula'
+        root.info.@module == 'ivypublishingtest'
+        root.info.@revision == '0.1.0'
+        root.info.@status == 'integration'
+        def artifact = root.publications.artifact[0]
+        artifact.@name == 'ivypublishingtest'
+        artifact.@type == 'jar'
+
+        def desc = root
+                .declareNamespace([nebula: 'http://netflix.com/build'])
+                .info[0].description[0]
+        desc.children().size() > 1
+        desc.'nebula:Implementation_Version' == '0.1.0'
+        desc.'nebula:Implementation_Title' == 'test.nebula#ivypublishingtest;0.1.0'
+        desc.'nebula:Module_Email' == 'nebula@example.test'
+
+        and:
+        !findDependency('com.google.guava', 'guava')
+
+        and:
+        fileWasPublished('ivypublishingtest-0.1.0.jar')
+        fileWasPublished('ivypublishingtest-0.1.0.jar.sha1')
+        fileWasPublished('ivypublishingtest-0.1.0.jar.sha256')
+        fileWasPublished('ivypublishingtest-0.1.0.jar.sha512')
+
+        fileWasPublished('ivypublishingtest-0.1.0-shadow.jar')
+        fileWasPublished('ivypublishingtest-0.1.0-shadow.jar.sha1')
+        fileWasPublished('ivypublishingtest-0.1.0-shadow.jar.sha256')
+        fileWasPublished('ivypublishingtest-0.1.0-shadow.jar.sha512')
+
+        fileWasPublished('ivypublishingtest-0.1.0.module')
+        fileWasPublished('ivypublishingtest-0.1.0.module.sha1')
+        fileWasPublished('ivypublishingtest-0.1.0.module.sha256')
+        fileWasPublished('ivypublishingtest-0.1.0.module.sha512')
+
+        fileWasPublished('ivy-0.1.0.xml')
+        fileWasPublished('ivy-0.1.0.xml.sha1')
+        fileWasPublished('ivy-0.1.0.xml.sha256')
+        fileWasPublished('ivy-0.1.0.xml.sha512')
     }
 
     def findDependency(String org, String name) {
@@ -260,5 +411,9 @@ public class DemoApplication {
         assert found.@rev == rev
         assert !conf || found.@conf == conf
         found
+    }
+
+    private boolean fileWasPublished(String fileName, String path = 'build/distIvy/test.nebula/ivypublishingtest/0.1.0/') {
+        return new File(projectDir, path + fileName).exists()
     }
 }

--- a/src/test/groovy/nebula/plugin/publishing/maven/MavenNebulaShadowJarPublishPluginIntegrationSpec.groovy
+++ b/src/test/groovy/nebula/plugin/publishing/maven/MavenNebulaShadowJarPublishPluginIntegrationSpec.groovy
@@ -54,10 +54,6 @@ class MavenNebulaShadowJarPublishPluginIntegrationSpec extends IntegrationTestKi
                     }
                 }
             }
-            
-            jar {
-              enabled = false // this configuration is used to produce only the shadowed jar
-            }
 
             jar.dependsOn shadowJar // this configuration is used to produce only the shadowed jar
 
@@ -71,6 +67,10 @@ class MavenNebulaShadowJarPublishPluginIntegrationSpec extends IntegrationTestKi
     def 'publish shadow jar with proper POM - no classifier'() {
         setup:
         buildFile << """
+            jar {
+              enabled = false // this configuration is used to produce only the shadowed jar
+            }
+
             shadowJar {
                 classifier null // this configuration is used to produce only the shadowed jar
                relocate 'com.google', 'com.netflix.shading.google'
@@ -105,17 +105,40 @@ public class DemoApplication {
         then:
         guava.version == '19.0'
 
-        when:
-        def jar = new File(projectDir, "build/libs/mavenpublishingtest-0.1.0.jar")
+        and:
+        fileWasPublished('mavenpublishingtest-0.1.0.jar')
+        fileWasPublished('mavenpublishingtest-0.1.0.jar.md5')
+        fileWasPublished('mavenpublishingtest-0.1.0.jar.sha1')
+        fileWasPublished('mavenpublishingtest-0.1.0.jar.sha256')
+        fileWasPublished('mavenpublishingtest-0.1.0.jar.sha512')
 
-        then:
-        jar.exists()
+        !fileWasPublished('mavenpublishingtest-0.1.0-all.jar')
+        !fileWasPublished('mavenpublishingtest-0.1.0-all.jar.md5')
+        !fileWasPublished('mavenpublishingtest-0.1.0-all.jar.sha1')
+        !fileWasPublished('mavenpublishingtest-0.1.0-all.jar.sha256')
+        !fileWasPublished('mavenpublishingtest-0.1.0-all.jar.sha512')
+
+        fileWasPublished('mavenpublishingtest-0.1.0.module')
+        fileWasPublished('mavenpublishingtest-0.1.0.module.md5')
+        fileWasPublished('mavenpublishingtest-0.1.0.module.sha1')
+        fileWasPublished('mavenpublishingtest-0.1.0.module.sha256')
+        fileWasPublished('mavenpublishingtest-0.1.0.module.sha512')
+
+        fileWasPublished('mavenpublishingtest-0.1.0.pom')
+        fileWasPublished('mavenpublishingtest-0.1.0.pom.md5')
+        fileWasPublished('mavenpublishingtest-0.1.0.pom.sha1')
+        fileWasPublished('mavenpublishingtest-0.1.0.pom.sha256')
+        fileWasPublished('mavenpublishingtest-0.1.0.pom.sha512')
     }
 
 
     def 'publish shadow jar with proper POM - with classifier'() {
         setup:
-        buildFile << """
+        buildFile << """            
+            jar {
+              enabled = false // this configuration is used to produce only the shadowed jar
+            }
+
             shadowJar {
                 classifier 'all' 
                relocate 'com.google', 'com.netflix.shading.google'
@@ -150,16 +173,39 @@ public class DemoApplication {
         then:
         guava.version == '19.0'
 
-        when:
-        def jar = new File(projectDir, "build/libs/mavenpublishingtest-0.1.0-all.jar")
+        and:
+        !fileWasPublished('mavenpublishingtest-0.1.0.jar')
+        !fileWasPublished('mavenpublishingtest-0.1.0.jar.md5')
+        !fileWasPublished('mavenpublishingtest-0.1.0.jar.sha1')
+        !fileWasPublished('mavenpublishingtest-0.1.0.jar.sha256')
+        !fileWasPublished('mavenpublishingtest-0.1.0.jar.sha512')
 
-        then:
-        jar.exists()
+        fileWasPublished('mavenpublishingtest-0.1.0-all.jar')
+        fileWasPublished('mavenpublishingtest-0.1.0-all.jar.md5')
+        fileWasPublished('mavenpublishingtest-0.1.0-all.jar.sha1')
+        fileWasPublished('mavenpublishingtest-0.1.0-all.jar.sha256')
+        fileWasPublished('mavenpublishingtest-0.1.0-all.jar.sha512')
+
+        fileWasPublished('mavenpublishingtest-0.1.0.module')
+        fileWasPublished('mavenpublishingtest-0.1.0.module.md5')
+        fileWasPublished('mavenpublishingtest-0.1.0.module.sha1')
+        fileWasPublished('mavenpublishingtest-0.1.0.module.sha256')
+        fileWasPublished('mavenpublishingtest-0.1.0.module.sha512')
+
+        fileWasPublished('mavenpublishingtest-0.1.0.pom')
+        fileWasPublished('mavenpublishingtest-0.1.0.pom.md5')
+        fileWasPublished('mavenpublishingtest-0.1.0.pom.sha1')
+        fileWasPublished('mavenpublishingtest-0.1.0.pom.sha256')
+        fileWasPublished('mavenpublishingtest-0.1.0.pom.sha512')
     }
 
     def 'publish shadow jar with proper POM - no classifier - manipulate xml'() {
         setup:
         buildFile << """
+            jar {
+              enabled = false // this configuration is used to produce only the shadowed jar
+            }
+
             shadowJar {
                 classifier null // this configuration is used to produce only the shadowed jar
                relocate 'com.google', 'com.netflix.shading.google'
@@ -225,11 +271,127 @@ public class DemoApplication {
         then:
         !guava
 
-        when:
-        def jar = new File(projectDir, "build/libs/mavenpublishingtest-0.1.0.jar")
+        and:
+        fileWasPublished('mavenpublishingtest-0.1.0.jar')
+        fileWasPublished('mavenpublishingtest-0.1.0.jar.md5')
+        fileWasPublished('mavenpublishingtest-0.1.0.jar.sha1')
+        fileWasPublished('mavenpublishingtest-0.1.0.jar.sha256')
+        fileWasPublished('mavenpublishingtest-0.1.0.jar.sha512')
 
-        then:
-        jar.exists()
+        !fileWasPublished('mavenpublishingtest-0.1.0-shadow.jar')
+        !fileWasPublished('mavenpublishingtest-0.1.0-shadow.jar.md5')
+        !fileWasPublished('mavenpublishingtest-0.1.0-shadow.jar.sha1')
+        !fileWasPublished('mavenpublishingtest-0.1.0-shadow.jar.sha256')
+        !fileWasPublished('mavenpublishingtest-0.1.0-shadow.jar.sha512')
+
+        fileWasPublished('mavenpublishingtest-0.1.0.module')
+        fileWasPublished('mavenpublishingtest-0.1.0.module.md5')
+        fileWasPublished('mavenpublishingtest-0.1.0.module.sha1')
+        fileWasPublished('mavenpublishingtest-0.1.0.module.sha256')
+        fileWasPublished('mavenpublishingtest-0.1.0.module.sha512')
+
+        fileWasPublished('mavenpublishingtest-0.1.0.pom')
+        fileWasPublished('mavenpublishingtest-0.1.0.pom.md5')
+        fileWasPublished('mavenpublishingtest-0.1.0.pom.sha1')
+        fileWasPublished('mavenpublishingtest-0.1.0.pom.sha256')
+        fileWasPublished('mavenpublishingtest-0.1.0.pom.sha512')
     }
 
+    def 'publish shadow jar with proper POM - with classifier and jar enabled - manipulate xml'() {
+        setup:
+        buildFile << """
+            shadowJar {
+                classifier 'shadow' 
+               relocate 'com.google', 'com.netflix.shading.google'
+            }
+            
+            afterEvaluate {
+             publishing {
+              publications {
+               // to remove shaded dependency from ivy.xml
+               withType(IvyPublication) {
+                descriptor.withXml {
+                 asNode()
+                   .dependencies
+                   .dependency
+                   .findAll {
+                    it.@name == "guava"
+                   }
+                   .each { it.parent().remove(it) }
+                }
+               }
+               // to remove shaded dependency from pom.xml
+               withType(MavenPublication) {
+                pom.withXml {
+                 asNode()
+                   .dependencies
+                   .dependency
+                   .findAll {
+                    it.artifactId.text() == "guava"
+                   }
+                   .each { it.parent().remove(it) }
+                }
+               }
+              }
+             }
+            }            
+"""
+        writeJavaSourceFile("""
+package demo;
+
+public class DemoApplication {
+
+    public static void main(String[] args) {
+        System.out.println(args);
+    }
+
+}
+
+""")
+        when:
+        def result = runTasks('shadowJar', 'publishNebulaPublicationToTestLocalRepository')
+
+        then:
+        def pom = new XmlSlurper().parse(new File(projectDir, 'build/publications/nebula/pom-default.xml'))
+        pom.version == '0.1.0'
+        pom.developers.developer[0].name == 'Nebula'
+        pom.properties.nebula_Module_Owner == 'nebula@example.test'
+        pom.url != null
+
+        when:
+        def dependencies = pom.dependencies.dependency
+        def guava = dependencies.find { it.artifactId == 'guava' }
+
+        then:
+        !guava
+
+        and:
+        fileWasPublished('mavenpublishingtest-0.1.0.jar')
+        fileWasPublished('mavenpublishingtest-0.1.0.jar.md5')
+        fileWasPublished('mavenpublishingtest-0.1.0.jar.sha1')
+        fileWasPublished('mavenpublishingtest-0.1.0.jar.sha256')
+        fileWasPublished('mavenpublishingtest-0.1.0.jar.sha512')
+
+        fileWasPublished('mavenpublishingtest-0.1.0-shadow.jar')
+        fileWasPublished('mavenpublishingtest-0.1.0-shadow.jar.md5')
+        fileWasPublished('mavenpublishingtest-0.1.0-shadow.jar.sha1')
+        fileWasPublished('mavenpublishingtest-0.1.0-shadow.jar.sha256')
+        fileWasPublished('mavenpublishingtest-0.1.0-shadow.jar.sha512')
+
+        fileWasPublished('mavenpublishingtest-0.1.0.module')
+        fileWasPublished('mavenpublishingtest-0.1.0.module.md5')
+        fileWasPublished('mavenpublishingtest-0.1.0.module.sha1')
+        fileWasPublished('mavenpublishingtest-0.1.0.module.sha256')
+        fileWasPublished('mavenpublishingtest-0.1.0.module.sha512')
+
+        fileWasPublished('mavenpublishingtest-0.1.0.pom')
+        fileWasPublished('mavenpublishingtest-0.1.0.pom.md5')
+        fileWasPublished('mavenpublishingtest-0.1.0.pom.sha1')
+        fileWasPublished('mavenpublishingtest-0.1.0.pom.sha256')
+        fileWasPublished('mavenpublishingtest-0.1.0.pom.sha512')
+    }
+
+    private boolean fileWasPublished(String fileName, String path = 'testrepo/test/nebula/mavenpublishingtest/0.1.0/') {
+        return new File(projectDir, path + fileName).exists()
+    }
 }


### PR DESCRIPTION
Introduced `MavenShadowPublishPlugin` and `IvyShadowPublishPlugin`. Both plugins leverage `ShadowJarPublicationConfigurer` to do the following when shadow plugin is present:

* if `jar` task is disabled and `shadow` classifier is null, the main artifact comes from `shadowJar`  task. ex. `myapp-0.1.0.jar`
* if `jar` task is disabled and `shadow` classifier is not null, the main artifact comes from `shadowJar` task. Ex. `myapp-0.1.0-all.jar`
* if `jar` task is enabled and `shadow` classifier is not null, the main artifact comes from `jar` and we attach `shadowJar` task artifact, too. Ex. `myapp-0.1.0-all.jar` and `myapp-0.1.0.jar`

Tests make sure that checksums and XML/module files are present, too.