### PR TITLE
Leverage Gradle's Built-in javadoc and sources packaging and publishing

### DIFF
--- a/src/main/groovy/nebula/plugin/publishing/publications/JavadocJarPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/publishing/publications/JavadocJarPlugin.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2015-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,62 +16,26 @@
 package nebula.plugin.publishing.publications
 
 import groovy.transform.CompileDynamic
-import nebula.plugin.publishing.ivy.IvyBasePublishPlugin
-import nebula.plugin.publishing.maven.MavenBasePublishPlugin
 import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPlugin
-import org.gradle.api.publish.ivy.IvyPublication
-import org.gradle.api.publish.maven.MavenPublication
-import org.gradle.api.tasks.TaskProvider
-import org.gradle.api.tasks.bundling.Jar
-import org.gradle.api.tasks.javadoc.Javadoc
+import org.gradle.api.plugins.JavaPluginExtension
 
 @CompileDynamic
 class JavadocJarPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
-        project.plugins.withType(JavaPlugin) {
-            TaskProvider<Javadoc> javadocTask = project.tasks.named('javadoc', Javadoc)
-            TaskProvider<Jar> javaDocJarTask = project.tasks.register('javadocJar', Jar)
-            javaDocJarTask.configure(new Action<Jar>() {
-                @Override
-                void execute(Jar jar) {
-                    jar.dependsOn javadocTask
-                    jar.from javadocTask
-                    jar.archiveClassifier.set 'javadoc'
-                    jar.archiveExtension.set 'jar'
-                    jar.group 'build'
-                }
-            })
-
-            project.plugins.withType(org.gradle.api.publish.maven.plugins.MavenPublishPlugin) {
-                project.plugins.apply(MavenBasePublishPlugin)
-
-                project.publishing {
-                    publications {
-                        nebula(MavenPublication) {
-                            artifact project.tasks.javadocJar
-                        }
+        project.plugins.withType(JavaPlugin).configureEach(new Action<JavaPlugin>() {
+            @Override
+            void execute(JavaPlugin javaPlugin) {
+                project.extensions.configure(JavaPluginExtension, new Action<JavaPluginExtension>() {
+                    @Override
+                    void execute(JavaPluginExtension extension) {
+                        extension.withJavadocJar()
                     }
-                }
+                })
             }
-
-            project.plugins.withType(org.gradle.api.publish.ivy.plugins.IvyPublishPlugin) {
-                project.plugins.apply(IvyBasePublishPlugin)
-
-                project.publishing {
-                    publications {
-                        nebulaIvy(IvyPublication) {
-                            artifact(project.tasks.javadocJar) {
-                                type 'javadoc'
-                                conf 'javadoc'
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        })
     }
 }

--- a/src/main/groovy/nebula/plugin/publishing/publications/JavadocJarPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/publishing/publications/JavadocJarPlugin.groovy
@@ -15,14 +15,12 @@
  */
 package nebula.plugin.publishing.publications
 
-import groovy.transform.CompileDynamic
 import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.JavaPluginExtension
 
-@CompileDynamic
 class JavadocJarPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {

--- a/src/main/groovy/nebula/plugin/publishing/publications/SourceJarPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/publishing/publications/SourceJarPlugin.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2015-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,63 +16,26 @@
 package nebula.plugin.publishing.publications
 
 import groovy.transform.CompileDynamic
-import nebula.plugin.publishing.ivy.IvyBasePublishPlugin
-import nebula.plugin.publishing.maven.MavenBasePublishPlugin
 import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPlugin
-import org.gradle.api.publish.ivy.IvyPublication
-import org.gradle.api.publish.ivy.plugins.IvyPublishPlugin
-import org.gradle.api.publish.maven.MavenPublication
-import org.gradle.api.publish.maven.plugins.MavenPublishPlugin
-import org.gradle.api.tasks.TaskProvider
-import org.gradle.api.tasks.bundling.Jar
+import org.gradle.api.plugins.JavaPluginExtension
 
 @CompileDynamic
 class SourceJarPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
-        project.plugins.withType(JavaPlugin) {
-            TaskProvider<Jar> sourceJarTask = project.tasks.register('sourceJar', Jar)
-            sourceJarTask.configure(new Action<Jar>() {
-                @Override
-                void execute(Jar jar) {
-                    jar.dependsOn project.tasks.named('classes')
-                    jar.from project.sourceSets.main.allSource
-                    jar.archiveClassifier.set 'sources'
-                    jar.archiveExtension.set 'jar'
-                    jar.group 'build'
-                }
-            })
-
-
-            project.plugins.withType(MavenPublishPlugin) {
-                project.plugins.apply(MavenBasePublishPlugin)
-
-                project.publishing {
-                    publications {
-                        nebula(MavenPublication) {
-                            artifact project.tasks.sourceJar
-                        }
+        project.plugins.withType(JavaPlugin).configureEach(new Action<JavaPlugin>() {
+            @Override
+            void execute(JavaPlugin javaPlugin) {
+                project.extensions.configure(JavaPluginExtension, new Action<JavaPluginExtension>() {
+                    @Override
+                    void execute(JavaPluginExtension extension) {
+                        extension.withSourcesJar()
                     }
-                }
+                })
             }
-
-            project.plugins.withType(IvyPublishPlugin) {
-                project.plugins.apply(IvyBasePublishPlugin)
-
-                project.publishing {
-                    publications {
-                        nebulaIvy(IvyPublication) {
-                            artifact(project.tasks.sourceJar) {
-                                type 'sources'
-                                conf 'sources'
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        })
     }
 }

--- a/src/main/groovy/nebula/plugin/publishing/publications/SourceJarPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/publishing/publications/SourceJarPlugin.groovy
@@ -15,14 +15,14 @@
  */
 package nebula.plugin.publishing.publications
 
-import groovy.transform.CompileDynamic
 import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.tasks.TaskProvider
 
-@CompileDynamic
 class SourceJarPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
@@ -33,6 +33,17 @@ class SourceJarPlugin implements Plugin<Project> {
                     @Override
                     void execute(JavaPluginExtension extension) {
                         extension.withSourcesJar()
+                    }
+                })
+
+                TaskProvider sourceJarTask = project.tasks.register('sourceJar')
+                sourceJarTask.configure(new Action<Task>() {
+                    @Override
+                    void execute(Task task) {
+                        task.dependsOn(project.tasks.named('sourcesJar'))
+                        task.doLast {
+                            project.logger.info("sourceJar task has been replaced by sourcesJar")
+                        }
                     }
                 })
             }

--- a/src/test/groovy/nebula/plugin/publishing/ivy/IvyExcludesPluginIntegrationSpec.groovy
+++ b/src/test/groovy/nebula/plugin/publishing/ivy/IvyExcludesPluginIntegrationSpec.groovy
@@ -67,11 +67,11 @@ class IvyExcludesPluginIntegrationSpec extends IntegrationTestKitSpec {
             }
 
             dependencies {
-                runtime('testjava:a:0.0.1') {
+                runtimeOnly('testjava:a:0.0.1') {
                     exclude group: 'testjava', module: 'ex1'
                     exclude module: 'ex2'
                 }
-                runtime('testjava:b:0.0.1') {
+                runtimeOnly('testjava:b:0.0.1') {
                     exclude group: 'testjava'
                 }
             }

--- a/src/test/groovy/nebula/plugin/publishing/ivy/interaction/IvyPublishRecommenderInteractionSpec.groovy
+++ b/src/test/groovy/nebula/plugin/publishing/ivy/interaction/IvyPublishRecommenderInteractionSpec.groovy
@@ -56,7 +56,7 @@ class IvyPublishRecommenderInteractionSpec extends IntegrationTestKitSpec {
         ivy.dependencies.dependency.first().@rev == '1.0.0'
 
         where:
-        scope << ['compile', 'implementation', 'api', 'runtimeOnly']
+        scope << ['implementation', 'api', 'runtimeOnly']
 
     }
 
@@ -110,7 +110,7 @@ class IvyPublishRecommenderInteractionSpec extends IntegrationTestKitSpec {
         ivy.dependencies.dependency.first().@rev == '1.0.0'
 
         where:
-        scope << ['compile', 'implementation', 'runtimeOnly']
+        scope << ['implementation', 'runtimeOnly']
 
     }
 

--- a/src/test/groovy/nebula/plugin/publishing/publications/JavadocJarPluginIntegrationSpec.groovy
+++ b/src/test/groovy/nebula/plugin/publishing/publications/JavadocJarPluginIntegrationSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2015-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -122,7 +122,7 @@ class JavadocJarPluginIntegrationSpec extends IntegrationSpec {
         def ivyXml = new XmlSlurper().parse(ivyXmlFile)
 
         then:
-        ivyXml.publications[0].artifact.find { it.@type == 'javadoc' && it.@conf == 'javadoc' }
+        ivyXml.publications[0].artifact.find { it.@type == 'jar' && it.@conf == 'javadocElements' }
     }
 
     def 'javadoc jar has content for ivy'() {

--- a/src/test/groovy/nebula/plugin/publishing/publications/SourceJarPluginIntegrationSpec.groovy
+++ b/src/test/groovy/nebula/plugin/publishing/publications/SourceJarPluginIntegrationSpec.groovy
@@ -78,6 +78,21 @@ class SourceJarPluginIntegrationSpec extends IntegrationSpec {
         ivyUnzipDir = new File(projectDir, 'unpackedIvy')
     }
 
+    def 'maintains backwards compatibility with sourceJar task'() {
+        buildFile << '''\
+            apply plugin: 'java'
+        '''.stripIndent()
+
+        writeHelloWorld('example')
+
+        when:
+        def result = runTasksSuccessfully('sourceJar', '--info')
+
+        then:
+        result.standardOutput.contains('sourceJar task has been replaced by sourcesJar')
+        new File(buildFile.parentFile, 'build/libs/sourcetest-0.1.0-sources.jar').exists()
+    }
+
     def 'creates a source jar with maven publishing'() {
         buildFile << '''\
             apply plugin: 'java'

--- a/src/test/groovy/nebula/plugin/publishing/publications/SourceJarPluginIntegrationSpec.groovy
+++ b/src/test/groovy/nebula/plugin/publishing/publications/SourceJarPluginIntegrationSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2015-2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -108,7 +108,7 @@ class SourceJarPluginIntegrationSpec extends IntegrationSpec {
         def ivyXml = new XmlSlurper().parse(ivyXmlFile)
 
         then:
-        ivyXml.publications[0].artifact.find { it.@type == 'sources' && it.@conf == 'sources' }
+        ivyXml.publications[0].artifact.find { it.@type == 'jar' && it.@conf == 'sourcesElements' }
     }
 
     def 'source jar contains java sources for maven publication'() {


### PR DESCRIPTION
This is for https://github.com/nebula-plugins/nebula-publishing-plugin/issues/157

Historically, nebula-publishing-plugin has been responsible for configuring source and javadoc jar tasks to add them to a publication and hook the tasks into the build process. Example of this:

```
project.plugins.withType(JavaPlugin) {
    TaskProvider<Javadoc> javadocTask = project.tasks.named('javadoc', Javadoc)
    TaskProvider<Jar> javaDocJarTask = project.tasks.register('javadocJar', Jar)
    javaDocJarTask.configure(new Action<Jar>() {
        @Override
        void execute(Jar jar) {
            jar.dependsOn javadocTask
            jar.from javadocTask
            jar.archiveClassifier.set 'javadoc'
            jar.archiveExtension.set 'jar'
            jar.group 'build'
        }
    })

    project.plugins.withType(org.gradle.api.publish.maven.plugins.MavenPublishPlugin) {
        project.plugins.apply(MavenBasePublishPlugin)

        project.publishing {
            publications {
                nebula(MavenPublication) {
                    artifact project.tasks.javadocJar
                }
            }
        }
    }

    project.plugins.withType(org.gradle.api.publish.ivy.plugins.IvyPublishPlugin) {
        project.plugins.apply(IvyBasePublishPlugin)

        project.publishing {
            publications {
                nebulaIvy(IvyPublication) {
                    artifact(project.tasks.javadocJar) {
                        type 'javadoc'
                        conf 'javadoc'
                    }
                }
            }
        }
    }
} 

```

We can remove the need to maintain this by leveraging source/javadoc new features from Gradle that were introduced in 6.0: https://docs.gradle.org/6.0/release-notes.html#javadoc-sources-jar