### PR TITLE
JavadocJar and SourceJar plugins should handle cases where 3rd party plugin registers those tasks without checking for existence

### DIFF
--- a/src/main/groovy/nebula/plugin/publishing/publications/JavadocJarPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/publishing/publications/JavadocJarPlugin.groovy
@@ -15,24 +15,78 @@
  */
 package nebula.plugin.publishing.publications
 
+import groovy.transform.CompileDynamic
+import nebula.plugin.publishing.ivy.IvyBasePublishPlugin
+import nebula.plugin.publishing.maven.MavenBasePublishPlugin
 import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.publish.ivy.IvyPublication
+import org.gradle.api.publish.ivy.plugins.IvyPublishPlugin
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.publish.maven.plugins.MavenPublishPlugin
+import org.gradle.jvm.tasks.Jar
 
+@CompileDynamic
 class JavadocJarPlugin implements Plugin<Project> {
+
+    private static final String JAVADOC_JAR_TASK = 'javadocJar'
+
     @Override
     void apply(Project project) {
-        project.plugins.withType(JavaPlugin).configureEach(new Action<JavaPlugin>() {
+        project.afterEvaluate {
+            project.plugins.withType(JavaPlugin){
+                if(javadocJarAlreadyExists(project)) {
+                    configureExistingJavadocTask(project)
+                } else {
+                    configureJavadocTask(project)
+                }
+            }
+        }
+    }
+
+    private boolean javadocJarAlreadyExists(Project project) {
+        return project.tasks.getNames().contains(JAVADOC_JAR_TASK)
+    }
+
+    private void configureJavadocTask(Project project) {
+        JavaPluginExtension javaPluginExtension = project.extensions.getByType(JavaPluginExtension)
+        javaPluginExtension.withJavadocJar()
+    }
+
+    private void configureExistingJavadocTask(Project project) {
+        project.tasks.named(JAVADOC_JAR_TASK, Jar).configure(new Action<Jar>() {
             @Override
-            void execute(JavaPlugin javaPlugin) {
-                project.extensions.configure(JavaPluginExtension, new Action<JavaPluginExtension>() {
-                    @Override
-                    void execute(JavaPluginExtension extension) {
-                        extension.withJavadocJar()
+            void execute(Jar task) {
+                task.dependsOn project.tasks.named('javadoc')
+                project.plugins.withType(MavenPublishPlugin) {
+                    project.plugins.apply(MavenBasePublishPlugin)
+
+                    project.publishing {
+                        publications {
+                            nebula(MavenPublication) {
+                                artifact task
+                            }
+                        }
                     }
-                })
+                }
+
+                project.plugins.withType(IvyPublishPlugin) {
+                    project.plugins.apply(IvyBasePublishPlugin)
+
+                    project.publishing {
+                        publications {
+                            nebulaIvy(IvyPublication) {
+                                artifact(task) {
+                                    type 'javadoc'
+                                    conf 'javadoc'
+                                }
+                            }
+                        }
+                    }
+                }
             }
         })
     }

--- a/src/main/groovy/nebula/plugin/publishing/publications/SourceJarPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/publishing/publications/SourceJarPlugin.groovy
@@ -15,37 +15,91 @@
  */
 package nebula.plugin.publishing.publications
 
+import groovy.transform.CompileDynamic
+import nebula.plugin.publishing.ivy.IvyBasePublishPlugin
+import nebula.plugin.publishing.maven.MavenBasePublishPlugin
 import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.publish.ivy.IvyPublication
+import org.gradle.api.publish.ivy.plugins.IvyPublishPlugin
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.publish.maven.plugins.MavenPublishPlugin
 import org.gradle.api.tasks.TaskProvider
+import org.gradle.jvm.tasks.Jar
 
+@CompileDynamic
 class SourceJarPlugin implements Plugin<Project> {
+
+    private static final String SOURCES_JAR_TASK = 'sourcesJar'
+
     @Override
     void apply(Project project) {
-        project.plugins.withType(JavaPlugin).configureEach(new Action<JavaPlugin>() {
-            @Override
-            void execute(JavaPlugin javaPlugin) {
-                project.extensions.configure(JavaPluginExtension, new Action<JavaPluginExtension>() {
-                    @Override
-                    void execute(JavaPluginExtension extension) {
-                        extension.withSourcesJar()
-                    }
-                })
+        project.afterEvaluate {
+            project.plugins.withType(JavaPlugin){
+                if(sourcesJarAlreadyExists(project)) {
+                    configureExistingSourcesJarTask(project)
+                } else {
+                    configureSourcesJarTask(project)
+                }
+            }
 
-                TaskProvider sourceJarTask = project.tasks.register('sourceJar')
-                sourceJarTask.configure(new Action<Task>() {
-                    @Override
-                    void execute(Task task) {
-                        task.dependsOn(project.tasks.named('sourcesJar'))
-                        task.doLast {
-                            project.logger.info("sourceJar task has been replaced by sourcesJar")
+            TaskProvider sourceJarTask = project.tasks.register('sourceJar')
+            sourceJarTask.configure(new Action<Task>() {
+                @Override
+                void execute(Task task) {
+                    task.dependsOn(project.tasks.named('sourcesJar'))
+                    task.doLast {
+                        project.logger.info("sourceJar task has been replaced by sourcesJar")
+                    }
+                }
+            })
+        }
+    }
+
+    private boolean sourcesJarAlreadyExists(Project project) {
+        return project.tasks.getNames().contains(SOURCES_JAR_TASK)
+    }
+
+    private void configureSourcesJarTask(Project project) {
+        JavaPluginExtension javaPluginExtension = project.extensions.getByType(JavaPluginExtension)
+        javaPluginExtension.withSourcesJar()
+    }
+
+    private void configureExistingSourcesJarTask(Project project) {
+        project.tasks.named(SOURCES_JAR_TASK, Jar).configure(new Action<Jar>() {
+            @Override
+            void execute(Jar task) {
+                task.dependsOn project.tasks.named('classes')
+                project.plugins.withType(MavenPublishPlugin) {
+                    project.plugins.apply(MavenBasePublishPlugin)
+
+                    project.publishing {
+                        publications {
+                            nebula(MavenPublication) {
+                                artifact task
+                            }
                         }
                     }
-                })
+                }
+
+                project.plugins.withType(IvyPublishPlugin) {
+                    project.plugins.apply(IvyBasePublishPlugin)
+
+                    project.publishing {
+                        publications {
+                            nebulaIvy(IvyPublication) {
+                                artifact(task) {
+                                    type 'sources'
+                                    conf 'sources'
+                                }
+                            }
+                        }
+                    }
+                }
             }
         })
     }

--- a/src/test/groovy/nebula/plugin/publishing/publications/JavadocJarPluginIntegrationSpec.groovy
+++ b/src/test/groovy/nebula/plugin/publishing/publications/JavadocJarPluginIntegrationSpec.groovy
@@ -139,6 +139,32 @@ class JavadocJarPluginIntegrationSpec extends IntegrationSpec {
         new File(ivyUnzipDir, 'example/HelloWorld.html').exists()
     }
 
+    def 'creates a javadoc jar with maven/ivy publishing and jpi plugin'() {
+        buildFile << '''\
+buildscript {
+  repositories {
+    maven {
+      url "https://plugins.gradle.org/m2/"
+    }
+  }
+  dependencies {
+    classpath "org.jenkins-ci.tools:gradle-jpi-plugin:0.38.0"
+  }
+}
+
+apply plugin: "org.jenkins-ci.jpi"
+
+            apply plugin: 'java'
+        '''.stripIndent()
+
+        when:
+        runTasksSuccessfully('publishNebulaPublicationToTestMavenRepository', 'publishNebulaIvyPublicationToTestIvyRepository', '--warning-mode', 'none')
+
+        then:
+        new File(mavenPublishDir, 'javadoctest-0.1.0-javadoc.jar').exists()
+        new File(ivyPublishDir, 'javadoctest-0.1.0-javadoc.jar').exists()
+    }
+
     private void createHelloWorld() {
         def src = new File(projectDir, 'src/main/java/example')
         src.mkdirs()

--- a/src/test/groovy/nebula/plugin/publishing/publications/SourceJarPluginIntegrationSpec.groovy
+++ b/src/test/groovy/nebula/plugin/publishing/publications/SourceJarPluginIntegrationSpec.groovy
@@ -198,6 +198,32 @@ class SourceJarPluginIntegrationSpec extends IntegrationSpec {
         helloWorld.text.contains 'class HelloWorld'
     }
 
+    def 'creates a source jar with maven/ivy publishing and jpi plugin'() {
+        buildFile << '''\
+buildscript {
+  repositories {
+    maven {
+      url "https://plugins.gradle.org/m2/"
+    }
+  }
+  dependencies {
+    classpath "org.jenkins-ci.tools:gradle-jpi-plugin:0.38.0"
+  }
+}
+
+apply plugin: "org.jenkins-ci.jpi"
+
+            apply plugin: 'java'
+        '''.stripIndent()
+
+        when:
+        runTasksSuccessfully('publishNebulaPublicationToTestMavenRepository', 'publishNebulaIvyPublicationToTestIvyRepository', '--warning-mode', 'none')
+
+        then:
+        new File(mavenPublishDir, 'sourcetest-0.1.0-sources.jar').exists()
+        new File(ivyPublishDir, 'sourcetest-0.1.0-sources.jar').exists()
+    }
+
     private void writeHelloGroovy() {
         def dir = new File(projectDir, 'src/main/groovy/example')
         dir.mkdirs()


### PR DESCRIPTION
We have the following build with MyPlugin and jenkins JPI plugin -> https://github.com/nebula-plugins/gradle-nebula-integration/blob/master/test-withSourcesJar/build.gradle

`MyPlugin` does something similar to what nebula-publishing might do which is read the `JavaPluginExtension` and enable sources/javadoc jars (https://github.com/nebula-plugins/gradle-nebula-integration/blob/master/test-withSourcesJar/buildSrc/src/main/groovy/test/MyPlugin.groovy)

The latest stable of the jpi plugin register the tasks as well: https://github.com/jenkinsci/gradle-jpi-plugin/blob/v0.38.0/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy#L120 causing the expected issue:

```
Caused by: org.gradle.api.internal.tasks.DefaultTaskContainer$DuplicateTaskException: Cannot add task 'sourcesJar' as a task with that name already exists.
        at org.gradle.api.internal.tasks.DefaultTaskContainer.failOnDuplicateTask(DefaultTaskContainer.java:261)
        at org.gradle.api.internal.tasks.DefaultTaskContainer.registerTask(DefaultTaskContainer.java:402)
        at org.gradle.api.internal.tasks.DefaultTaskContainer.register(DefaultTaskContainer.java:379)
        at org.gradle.api.internal.tasks.DefaultTaskContainer.register(DefaultTaskContainer.java:76)
        at org.gradle.api.internal.tasks.DefaultTaskContainer_Decorated.register(Unknown Source)
        at org.gradle.api.internal.tasks.DefaultTaskContainer_Decorated$register$0.call(Unknown Source)
        at org.jenkinsci.gradle.plugins.jpi.JpiPlugin.apply(JpiPlugin.groovy:120)
        at org.jenkinsci.gradle.plugins.jpi.JpiPlugin.apply(JpiPlugin.groovy)
```

Future versions of the plugin appear to be refactored to follow the withSourcesJar and withJavadocJar conventions: https://github.com/jenkinsci/gradle-jpi-plugin/blob/v0.39.0-rc.2/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy#L106

This should be idempotent,  I think I know the answer by looking at https://github.com/gradle/gradle/blob/master/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginExtension.java#L120 and https://github.com/gradle/gradle/blob/master/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JvmPluginsHelper.java#L225 

However, we should probably handle any other potential plugin doing this

This PR configures existing javadoc/sources jar to be part of the publications. This works with the jpi plugin.

Projects without existing tasks for this, will continue to use Gradle's ergonomics, example:

```
 JavaPluginExtension javaPluginExtension = project.extensions.getByType(JavaPluginExtension)
 javaPluginExtension.withSourcesJar()
``` 