### PR TITLE
Update deprecated reference to shadowJar.classifier

### DIFF
--- a/src/test/groovy/nebula/plugin/publishing/ivy/IvyNebulaShadowJarPublishPluginIntegrationSpec.groovy
+++ b/src/test/groovy/nebula/plugin/publishing/ivy/IvyNebulaShadowJarPublishPluginIntegrationSpec.groovy
@@ -71,7 +71,7 @@ class IvyNebulaShadowJarPublishPluginIntegrationSpec extends IntegrationTestKitS
             }
             
             shadowJar {
-                classifier null // this configuration is used to produce only the shadowed jar
+               archiveClassifier.set(null) // this configuration is used to produce only the shadowed jar
                relocate 'com.google', 'com.netflix.shading.google'
             }
 """


### PR DESCRIPTION
The new configuration is a `Property` called `archiveClassifier`.