### PR TITLE
VerifyPublicationTaskSpec: switch to patternLayout for ivy repository config

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-rc-1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/test/groovy/nebula/plugin/publishing/verification/VerifyPublicationTaskSpec.groovy
+++ b/src/test/groovy/nebula/plugin/publishing/verification/VerifyPublicationTaskSpec.groovy
@@ -6,7 +6,6 @@ import nebula.test.dependencies.GradleDependencyGenerator
 import nebula.test.dependencies.ModuleBuilder
 import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.api.artifacts.ComponentMetadataDetails
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.testfixtures.ProjectBuilder
@@ -166,7 +165,7 @@ class VerifyPublicationTaskSpec extends Specification {
         project.repositories {
             ivy {
                 url generator.getIvyRepoUrl()
-                layout('pattern') {
+                patternLayout {
                     ivy '[organisation]/[module]/[revision]/[module]-[revision]-ivy.[ext]'
                     artifact '[organisation]/[module]/[revision]/[artifact]-[revision](-[classifier]).[ext]'
                     m2compatible = true


### PR DESCRIPTION
In new versions of Gradle, `VerifyPublicationTaskSpec` will fail with:

```
nebula.plugin.publishing.verification.VerifyPublicationTaskSpec > test error collection when combinations of statuses library=integration project=milestone FAILED
    org.gradle.internal.metaobject.AbstractDynamicObject$CustomMessageMissingMethodException: Could not find method layout() for arguments [pattern, nebula.plugin.publishing.verification.VerifyPublicationTaskSpec$_populateAndSetRepository_closure2$_closure9$_closure10@62ce6c14] on object of type org.gradle.api.internal.artifacts.repositories.DefaultIvyArtifactRepository.
        at org.gradle.internal.metaobject.AbstractDynamicObject$CustomMissingMethodExecutionFailed.<init>(AbstractDynamicObject.java:190)
        at org.gradle.internal.metaobject.AbstractDynamicObject.methodMissingException(AbstractDynamicObject.java:184)
        at org.gradle.internal.metaobject.ConfigureDelegate.invokeMethod(ConfigureDelegate.java:86)
        at nebula.plugin.publishing.verification.VerifyPublicationTaskSpec.populateAndSetRepository_closure2$_closure9(VerifyPublicationTaskSpec.groovy:169)
        at groovy.lang.Closure.call(Closure.java:405)
        at groovy.lang.Closure.call(Closure.java:421)
        at org.gradle.util.ClosureBackedAction.execute(ClosureBackedAction.java:71)
        at org.gradle.util.ConfigureUtil.configureTarget(ConfigureUtil.java:154)
        at org.gradle.util.ConfigureUtil.configure(ConfigureUtil.java:105)
``` 