### PR TITLE
PublishVerification task handles constraints that come from core Gradle locking

### DIFF
--- a/src/main/groovy/nebula/plugin/publishing/verification/VerifyPublicationTask.groovy
+++ b/src/main/groovy/nebula/plugin/publishing/verification/VerifyPublicationTask.groovy
@@ -36,6 +36,7 @@ class VerifyPublicationTask extends DefaultTask {
 
     private Set<ResolvedDependencyResult> getNonProjectDependencies(Configuration runtimeClasspath) {
         Set<? extends DependencyResult> firstLevelDependencies = runtimeClasspath.incoming.resolutionResult.root.getDependencies()
+                .findAll { !it.constraint }
         List<UnresolvedDependencyResult> unresolvedDependencies = firstLevelDependencies.findAll { it instanceof UnresolvedDependencyResult } as List<UnresolvedDependencyResult>
         if (! unresolvedDependencies.isEmpty()) {
             UnresolvedDependencyResult unresolvedDependencyResult = (UnresolvedDependencyResult) unresolvedDependencies.first()


### PR DESCRIPTION
PublishVerification task handles constraints that come from core Gradle locking so that transitive dependencies are not counted as first-level dependencies

DependencyResult constraint has been available since Gradle 5.1