### PR TITLE
Speed up configuration time by recycling rootProject's git info

### DIFF
--- a/src/main/groovy/nebula/plugin/publishing/maven/MavenBasePublishPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/publishing/maven/MavenBasePublishPlugin.groovy
@@ -26,14 +26,6 @@ import org.gradle.api.publish.maven.MavenPublication
 class MavenBasePublishPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
-
-
-        // Capture the start time in milliseconds
-        long startTime = System.currentTimeMillis();
-
-
-
-
         project.plugins.apply org.gradle.api.publish.maven.plugins.MavenPublishPlugin
 
         PublishingExtension publishing = project.extensions.getByType(PublishingExtension)
@@ -54,13 +46,6 @@ class MavenBasePublishPlugin implements Plugin<Project> {
                 }
             }
         })
-
-//        // Capture the end time in milliseconds
-//        long endTime = System.currentTimeMillis();
-//
-//        // Calculate and print the duration
-//        long duration = endTime - startTime;
-//        System.out.println("Execution took " + duration + " milliseconds.");
     }
 
     private static void configureDescription(MavenPublication publication, Project p) {

--- a/src/main/groovy/nebula/plugin/publishing/maven/MavenBasePublishPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/publishing/maven/MavenBasePublishPlugin.groovy
@@ -26,6 +26,14 @@ import org.gradle.api.publish.maven.MavenPublication
 class MavenBasePublishPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
+
+
+        // Capture the start time in milliseconds
+        long startTime = System.currentTimeMillis();
+
+
+
+
         project.plugins.apply org.gradle.api.publish.maven.plugins.MavenPublishPlugin
 
         PublishingExtension publishing = project.extensions.getByType(PublishingExtension)
@@ -46,6 +54,13 @@ class MavenBasePublishPlugin implements Plugin<Project> {
                 }
             }
         })
+
+//        // Capture the end time in milliseconds
+//        long endTime = System.currentTimeMillis();
+//
+//        // Calculate and print the duration
+//        long duration = endTime - startTime;
+//        System.out.println("Execution took " + duration + " milliseconds.");
     }
 
     private static void configureDescription(MavenPublication publication, Project p) {

--- a/src/main/groovy/nebula/plugin/publishing/maven/MavenScmPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/publishing/maven/MavenScmPlugin.groovy
@@ -32,8 +32,6 @@ class MavenScmPlugin implements Plugin<Project> {
 
     @Override
     void apply(Project project) {
-        // Capture the start time in milliseconds
-        long startTime = System.currentTimeMillis();
         project.plugins.apply MavenBasePublishPlugin
 
         try {
@@ -45,9 +43,10 @@ class MavenScmPlugin implements Plugin<Project> {
 
         project.plugins.withType(ScmInfoPlugin) { ScmInfoPlugin scmInfo ->
             def publishingExtension = project.extensions.getByType(PublishingExtension)
+            // Using rootProject's git info for performance reasons instead of having to re-calculate it
+            // in every subproject.
             def scmExtension = project.rootProject.extensions.getByType(ScmInfoExtension)
 
-            System.out.println("Execution 1 took " + (System.currentTimeMillis() - startTime) + " milliseconds.");
             publishingExtension.publications(new Action<PublicationContainer>() {
                 @Override
                 void execute(PublicationContainer publications) {
@@ -60,8 +59,6 @@ class MavenScmPlugin implements Plugin<Project> {
                                 }
                             })
                         }
-                        System.out.println("Execution 2 took " + (System.currentTimeMillis() - startTime) + " milliseconds.");
-
                         publication.pom(new Action<MavenPom>() {
                             @Override
                             void execute(MavenPom pom) {
@@ -73,14 +70,10 @@ class MavenScmPlugin implements Plugin<Project> {
                                 })
                             }
                         })
-                        System.out.println("Execution 3 took " + (System.currentTimeMillis() - startTime) + " milliseconds.");
-
                     }
                 }
             })
         }
-
-
     }
 
     static final GIT_PATTERN = /((git|ssh|https?):(\/\/))?(\w+@)?([\w\.@\\/\-~]+)([\:\\/])([\w\.@\:\/\-~]+)(\.git)(\/)?/

--- a/src/main/groovy/nebula/plugin/publishing/maven/MavenScmPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/publishing/maven/MavenScmPlugin.groovy
@@ -30,8 +30,12 @@ import org.gradle.api.publish.maven.MavenPublication
 
 class MavenScmPlugin implements Plugin<Project> {
 
+    String c = null;
+
     @Override
     void apply(Project project) {
+        // Capture the start time in milliseconds
+        long startTime = System.currentTimeMillis();
         project.plugins.apply MavenBasePublishPlugin
 
         try {
@@ -44,6 +48,8 @@ class MavenScmPlugin implements Plugin<Project> {
         project.plugins.withType(ScmInfoPlugin) { ScmInfoPlugin scmInfo ->
             def publishingExtension = project.extensions.getByType(PublishingExtension)
             def scmExtension = project.extensions.getByType(ScmInfoExtension)
+
+            System.out.println("Execution 1 took " + (System.currentTimeMillis() - startTime) + " milliseconds.");
             publishingExtension.publications(new Action<PublicationContainer>() {
                 @Override
                 void execute(PublicationContainer publications) {
@@ -52,10 +58,15 @@ class MavenScmPlugin implements Plugin<Project> {
                             publication.pom(new Action<MavenPom>() {
                                 @Override
                                 void execute(MavenPom pom) {
-                                    pom.url.set(calculateUrlFromOrigin(scmExtension.origin, project))
+                                    if (c == null) {
+                                        c = calculateUrlFromOrigin(scmExtension.origin, project)
+                                    }
+                                    pom.url.set(c)
                                 }
                             })
                         }
+                        System.out.println("Execution 2 took " + (System.currentTimeMillis() - startTime) + " milliseconds.");
+
                         publication.pom(new Action<MavenPom>() {
                             @Override
                             void execute(MavenPom pom) {
@@ -67,10 +78,14 @@ class MavenScmPlugin implements Plugin<Project> {
                                 })
                             }
                         })
+                        System.out.println("Execution 3 took " + (System.currentTimeMillis() - startTime) + " milliseconds.");
+
                     }
                 }
             })
         }
+
+
     }
 
     static final GIT_PATTERN = /((git|ssh|https?):(\/\/))?(\w+@)?([\w\.@\\/\-~]+)([\:\\/])([\w\.@\:\/\-~]+)(\.git)(\/)?/

--- a/src/main/groovy/nebula/plugin/publishing/maven/MavenScmPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/publishing/maven/MavenScmPlugin.groovy
@@ -30,8 +30,6 @@ import org.gradle.api.publish.maven.MavenPublication
 
 class MavenScmPlugin implements Plugin<Project> {
 
-    String c = null;
-
     @Override
     void apply(Project project) {
         // Capture the start time in milliseconds
@@ -47,7 +45,7 @@ class MavenScmPlugin implements Plugin<Project> {
 
         project.plugins.withType(ScmInfoPlugin) { ScmInfoPlugin scmInfo ->
             def publishingExtension = project.extensions.getByType(PublishingExtension)
-            def scmExtension = project.extensions.getByType(ScmInfoExtension)
+            def scmExtension = project.rootProject.extensions.getByType(ScmInfoExtension)
 
             System.out.println("Execution 1 took " + (System.currentTimeMillis() - startTime) + " milliseconds.");
             publishingExtension.publications(new Action<PublicationContainer>() {
@@ -58,10 +56,7 @@ class MavenScmPlugin implements Plugin<Project> {
                             publication.pom(new Action<MavenPom>() {
                                 @Override
                                 void execute(MavenPom pom) {
-                                    if (c == null) {
-                                        c = calculateUrlFromOrigin(scmExtension.origin, project)
-                                    }
-                                    pom.url.set(c)
+                                    pom.url.set(calculateUrlFromOrigin(scmExtension.origin, project))
                                 }
                             })
                         }


### PR DESCRIPTION
### Problem

`com.netflix.nebula.maven-scm` will record some of the git info for publishing. It does the git info calculation at every project, which makes configuration time longer than necessary because the git info is not going to change for any project in the repo, especially in this case, we only want `origin.`

### Solution

Reuse rootProjects' git info. 

### Effect

For repo with 175 projects, we see about 7s reduction for whole repo configuration.