### PR TITLE
fix: Handle `git@` urls that don't end in `.git`

### DIFF
--- a/src/main/groovy/nebula/plugin/publishing/maven/MavenScmPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/publishing/maven/MavenScmPlugin.groovy
@@ -15,7 +15,7 @@
  */
 package nebula.plugin.publishing.maven
 
-import groovy.transform.CompileDynamic
+
 import nebula.plugin.info.scm.GitScmProvider
 import nebula.plugin.info.scm.ScmInfoExtension
 import nebula.plugin.info.scm.ScmInfoPlugin
@@ -76,17 +76,16 @@ class MavenScmPlugin implements Plugin<Project> {
         }
     }
 
-    static final GIT_PATTERN = /((git|ssh|https?):(\/\/))?(\w+@)?([\w\.@\\/\-~]+)([\:\\/])([\w\.@\:\/\-~]+)(\.git)(\/)?/
+    static final GIT_PATTERN = /^((git|ssh|https?):\/\/)?((\S+)@)?(?<host>\S+?)[:\/](?<repo>\S+?)(.git)?\/?$/
 
     /**
      * Convert git syntax of git@github.com:reactivex/rxjava-core.git to https://github.com/reactivex/rxjava-core
      * @param origin
      */
-    @CompileDynamic
     static String calculateUrlFromOrigin(String origin, Project project) {
         def m = origin =~ GIT_PATTERN
-        if (m) {
-            return "https://${m[0][5]}/${m[0][7]}"
+        if (m.matches()) {
+            return "https://${m.group("host")}/${m.group("repo")}"
         } else {
             project.logger.warn("Unable to convert $origin to https form in MavenScmPlugin. Using original value.")
             return origin

--- a/src/test/groovy/nebula/plugin/publishing/maven/MavenScmPluginSpec.groovy
+++ b/src/test/groovy/nebula/plugin/publishing/maven/MavenScmPluginSpec.groovy
@@ -37,9 +37,10 @@ class MavenScmPluginSpec extends PluginProjectSpec {
         scmOrigin                                                        | calculatedUrl
         'https://fake-scm.com/foo/bar.git'                               | 'https://fake-scm.com/foo/bar'
         'https://github.com/nebula-plugins/nebula-publishing-plugin'     | 'https://github.com/nebula-plugins/nebula-publishing-plugin'
+        'https://github.com/nebula-plugins/nebula-publishing-plugin/'    | 'https://github.com/nebula-plugins/nebula-publishing-plugin'
         'https://github.com/nebula-plugins/nebula-publishing-plugin.git' | 'https://github.com/nebula-plugins/nebula-publishing-plugin'
         'git@github.com:nebula-plugins/nebula-publishing-plugin.git'     | 'https://github.com/nebula-plugins/nebula-publishing-plugin'
         'git@github.com:username/nebula-publishing-plugin.git'           | 'https://github.com/username/nebula-publishing-plugin'
-        'git@github.com:username/nebula-publishing-plugin.git'           | 'https://github.com/username/nebula-publishing-plugin'
+        'git@github.com:username/nebula-publishing-plugin'               | 'https://github.com/username/nebula-publishing-plugin'
     }
 }


### PR DESCRIPTION
Prior to this, something like would log a warning.

```
git@github.com:username/nebula-publishing-plugin
```

This change handles it correctly.
